### PR TITLE
changed password to a getpass prompt for all sorts of security reasons

### DIFF
--- a/rtv/main.py
+++ b/rtv/main.py
@@ -6,6 +6,8 @@ from rtv.errors import SubmissionURLError, SubredditNameError
 from rtv.utils import curses_session
 from rtv.subreddit import SubredditPage
 from rtv.submission import SubmissionPage
+import ConfigParser
+from getpass import getpass
 
 description = """
 Reddit Terminal Viewer is a lightweight browser for www.reddit.com built into a
@@ -30,7 +32,6 @@ def main():
 
     group = parser.add_argument_group('authentication (optional)')
     group.add_argument('-u', dest='username', help='reddit username')
-    group.add_argument('-p', dest='password', help='reddit password')
 
     args = parser.parse_args()
 
@@ -38,8 +39,9 @@ def main():
         reddit = praw.Reddit(user_agent='reddit terminal viewer v0.0')
         reddit.config.decode_html_entities = True
 
-        if args.username and args.password:
-            reddit.login(args.username, args.password)
+        if args.username:
+            password = getpass()
+            reddit.login(args.username, password)
 
         with curses_session() as stdscr:
 

--- a/rtv/main.py
+++ b/rtv/main.py
@@ -6,7 +6,6 @@ from rtv.errors import SubmissionURLError, SubredditNameError
 from rtv.utils import curses_session
 from rtv.subreddit import SubredditPage
 from rtv.submission import SubmissionPage
-import ConfigParser
 from getpass import getpass
 
 description = """
@@ -32,6 +31,7 @@ def main():
 
     group = parser.add_argument_group('authentication (optional)')
     group.add_argument('-u', dest='username', help='reddit username')
+    group.add_argument('-p', dest='password', help='reddit password')
 
     args = parser.parse_args()
 
@@ -40,8 +40,11 @@ def main():
         reddit.config.decode_html_entities = True
 
         if args.username:
-            password = getpass()
-            reddit.login(args.username, password)
+            if args.password:
+                reddit.login(args.username, args.password)
+            else:
+                password = getpass()
+                reddit.login(args.username, password)
 
         with curses_session() as stdscr:
 


### PR DESCRIPTION
Previously, your password is both visible on the command line as you type it as well as stored in your terminal history. This will prompt the user for their password using Python's built-in getpass module, which will keep it far more secure.