### PR TITLE
Pressing '?' crashes the client

### DIFF
--- a/rtv/curses_helpers.py
+++ b/rtv/curses_helpers.py
@@ -60,7 +60,7 @@ def show_help(stdscr):
     """
     Overlay a message box with the help screen.
     """
-    show_notification(stdscr, docs.HELP.split("\n"))
+    show_notification(stdscr, HELP.split("\n"))
 
 class LoadScreen(object):
     """


### PR DESCRIPTION
I updated an import changing `docs.HELP.split('\n')` to `HELP.split('\n')` now shows help appropriately.