### PR TITLE
Add version.py to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include version.py


### PR DESCRIPTION
Otherwise, version.py would not be included by `setup.py sdist`, making
the package on PyPi unusable.