### PR TITLE
fixed bug for author highlighting in comments

### DIFF
--- a/rtv/content.py
+++ b/rtv/content.py
@@ -74,7 +74,7 @@ class BaseContent(object):
             data['score'] = '{} pts'.format(comment.score)
             author = getattr(comment, 'author')
             data['author'] = (author.name if author else '[deleted]')
-            sub_author = getattr(comment.submission, 'author')
+            sub_author = getattr(comment.submission.author, 'name')
             data['is_author'] = (data['author'] == sub_author)
             flair = comment.author_flair_text
             data['flair'] = (flair if flair else '')


### PR DESCRIPTION
We were comparing the name to the author which was never true. This was causing the author's name to never be highlighted green in the comments.

Fixed so `data['is_author']` is now correct.