### PR TITLE
added program title to terminal title

### DIFF
--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -15,6 +15,7 @@ from .curses_helpers import curses_session
 from .submission import SubmissionPage
 from .subreddit import SubredditPage
 from .docs import *
+from .__version__ import __version__
 
 __all__ = []
 
@@ -67,6 +68,13 @@ def main():
 
     args = command_line()
     local_config = load_config()
+
+    # set the terminal title
+    title = 'rtv {0}'.format(__version__)
+    try:
+        sys.stdout.write("\x1b]2;{0}\x07".format(title))
+    except:
+        os.system(title)
 
     # Fill in empty arguments with config file values. Paramaters explicitly
     # typed on the command line will take priority over config file params.

--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -71,10 +71,10 @@ def main():
 
     # set the terminal title
     title = 'rtv {0}'.format(__version__)
-    try:
+    if os.name == 'nt':
+        os.system('title {0}'.format(title))
+    else:
         sys.stdout.write("\x1b]2;{0}\x07".format(title))
-    except:
-        os.system(title)
 
     # Fill in empty arguments with config file values. Paramaters explicitly
     # typed on the command line will take priority over config file params.


### PR DESCRIPTION
Displays the name and version in the terminal title. Nothing too fancy, just helps when you have 5 terminals open :D

Tested on linux. The first method works for linux and OSX. The second should work for Windows..

![](http://i.imgur.com/OQVqCg3.png)