### PR TITLE
toggle hidden comment with arrow left or h

### DIFF
--- a/rtv/content.py
+++ b/rtv/content.py
@@ -229,6 +229,10 @@ class SubmissionContent(BaseContent):
         else:
             raise ValueError('% type not recognized' % data['type'])
 
+    def is_hidden_comment(self, index):
+        data = self.get(index)
+        return data['type'] == 'HiddenComment'
+
 
 class SubredditContent(BaseContent):
 

--- a/rtv/submission.py
+++ b/rtv/submission.py
@@ -53,7 +53,11 @@ class SubmissionPage(BasePage):
 
     @SubmissionController.register(curses.KEY_LEFT, 'h')
     def exit_submission(self):
-        self.active = False
+        index = self.nav.absolute_index
+        if self.content.is_hidden_comment(index):
+            self.content.toggle(index)
+        else:
+            self.active = False
 
     @SubmissionController.register(curses.KEY_F5, 'r')
     def refresh_content(self):


### PR DESCRIPTION
I can't count how many times I've pressed the left arrow to un-hide a comment and have been kicked back out the the sub. I figured if I'm having this problem others might as well.

This simple change checks to see if the comment is hidden on `KEY_LEFT` or `h` key presses and if it is, it un-hide it instead of exiting to the subreddit

EDIT: You won't hurt my feelings if this doesn't get added, I just thought it might be useful :)