### PR TITLE
Read config from XDG_CONFIG_HOME (Fix #65)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,13 +91,11 @@ In submission mode you can view the self text for a submission and browse commen
 Configuration
 -------------
 
-RTV will read a configuration file located at **~/.rtv**.
+RTV will read a configuration file located at ``$XDG_CONFIG_HOME/rtv/rtv.cfg`` or ``~/.config/rtv/rtv.cfg`` if ``$XDG_CONFIG_HOME`` is not set.
 This can be used to avoid having to re-enter login credentials every time the program is launched.
 Each line in the file will replace the corresponding default argument in the launch script.
 
 Example config:
-
-**~/.rtv**
 
 .. code-block:: ini
 

--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -26,9 +26,20 @@ def load_config():
     saved settings for things like the username and password.
     """
 
-    config_path = os.path.join(os.path.expanduser('~'), '.rtv')
     config = configparser.ConfigParser()
-    config.read(config_path)
+
+    HOME = os.path.expanduser('~')
+    XDG_CONFIG_HOME = os.getenv('XDG_CONFIG_HOME', os.path.join(HOME, '.config'))
+    config_paths = [
+        os.path.join(XDG_CONFIG_HOME, 'rtv', 'rtv.cfg'),
+        os.path.join(HOME, '.rtv')
+    ]
+
+    # read only the first existing config file
+    for config_path in config_paths:
+        if os.path.exists(config_path):
+            config.read(config_path)
+            break
 
     defaults = {}
     if config.has_section('rtv'):


### PR DESCRIPTION
Config file is read from the first of these two locations:
* $XDG_CONFIG_HOME/rtv/rtv.cfg
* ~/.rtv