### PR TITLE
Don't show flair when it's None

### DIFF
--- a/rtv/submission.py
+++ b/rtv/submission.py
@@ -222,7 +222,8 @@ class SubmissionPage(BasePage):
         attr = curses.A_BOLD | Color.GREEN
         add_line(win, u'{author}'.format(**data), row, 1, attr)
         attr = curses.A_BOLD | Color.YELLOW
-        add_line(win, u' {flair}'.format(**data), attr=attr)
+        if data['flair']:
+            add_line(win, u' {flair}'.format(**data), attr=attr)
         add_line(win, u' {created} {subreddit}'.format(**data))
 
         row = len(data['split_title']) + 2

--- a/rtv/subreddit.py
+++ b/rtv/subreddit.py
@@ -196,4 +196,5 @@ class SubredditPage(BasePage):
         if row in valid_rows:
             add_line(win, u'{author}'.format(**data), row, 1, curses.A_BOLD)
             add_line(win, u' {subreddit}'.format(**data), attr=Color.YELLOW)
-            add_line(win, u' {flair}'.format(**data), attr=Color.RED)
+            if data['flair']:
+                add_line(win, u' {flair}'.format(**data), attr=Color.RED)


### PR DESCRIPTION
praw could return None for \*flair\* params, don't show this.

Thats's what I saw before this fix:
![rtv-01](https://cloud.githubusercontent.com/assets/5208820/8554507/e3d35cde-24f2-11e5-9db9-ffc7bf106617.png)
and
![rtv-02](https://cloud.githubusercontent.com/assets/5208820/8554512/e968e2ae-24f2-11e5-9cc0-d1209e5476fa.png)