### PR TITLE
OAuth terminal web browser support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,17 +155,9 @@ If you prefer to stay in the terminal, use ``$BROWSER`` to specify a console-bas
 Config File
 -----------
 
-RTV will read two configuration files:
-
-* ``~/.config/rtv/rtv.cfg`` (or ``$XDG_CONFIG_HOME/.rtv``)
-* ``~/.config/rtv/oauth.cfg`` (or ``$XDG_CONFIG_HOME/.rtv-oauth``)
-
+RTV will read a configuration placed at ``~/.config/rtv/rtv.cfg`` (or ``$XDG_CONFIG_HOME``).
 Each line in the files will replace the corresponding default argument in the launch script.
 This can be used to avoid having to re-enter login credentials every time the program is launched.
-
-The OAuth section contains a boolean to trigger auto-login (defaults to false).
-When authenticated, two additional fields are written : **access_token** and **refresh_token**.
-Those are basically like username and password : they are used to authenticate you on Reddit servers.
 
 Example initial config:
 
@@ -187,7 +179,19 @@ Example initial config:
   # This may be necessary for compatibility with some terminal browsers
   # ascii=True
 
-**oauth.cfg**
+-----
+OAuth
+-----
+
+OAuth is an authentication standard, that replaces authentication with login and password.
+
+RTV implements OAuth. It stores OAuth configuration at ``~/.config/rtv/oauth.cfg``(or ``$XDG_CONFIG_HOME``).
+**The OAuth configuration file must be writable, and is created automatically if it doesn't exist.**
+It contains a boolean to trigger auto-login (defaults to false).
+When authenticated, an additional field is written : **refresh_token**.
+This acts as a replacement to username and password : it is used to authenticate you on Reddit servers.
+
+Example **oauth.cfg**:
 
 .. code-block:: ini
 

--- a/rtv/docs.py
+++ b/rtv/docs.py
@@ -18,8 +18,8 @@ given, the program will display a secure prompt to enter a password.
 """
 
 OAUTH = """\
-Authentication is now done by OAuth, since PRAW will stop supporting login with
-username and password soon.
+Authentication is now done by OAuth, since PRAW will drop
+password authentication soon.
 """
 
 CONTROLS = """

--- a/rtv/oauth.py
+++ b/rtv/oauth.py
@@ -28,6 +28,9 @@ class HomeHandler(web.RequestHandler):
 
 class AuthHandler(web.RequestHandler):
 
+    def initialize(self):
+        self.compact = os.environ.get('BROWSER') in ['w3m', 'links', 'elinks', 'lynx']
+
     def get(self):
         global oauth_state
         global oauth_code
@@ -38,6 +41,10 @@ class AuthHandler(web.RequestHandler):
         oauth_error = self.get_argument('error', default='error_placeholder')
 
         self.render('auth.html', state=oauth_state, code=oauth_code, error=oauth_error)
+
+        # Stop IOLoop if using BackgroundBrowser (or GUI browser)
+        if not self.compact:
+            ioloop.IOLoop.current().stop()
 
 class OAuthTool(object):
 

--- a/rtv/oauth.py
+++ b/rtv/oauth.py
@@ -63,12 +63,11 @@ class OAuthTool(object):
         # Terminal web browser
         self.compact = os.environ.get('BROWSER') in ['w3m', 'links', 'elinks', 'lynx']
 
-        # Initialize Tornado webapp and listen on port 65000
+        # Initialize Tornado webapp
         self.callback_app = web.Application([
             (r'/', HomeHandler),
             (r'/auth', AuthHandler),
         ], template_path='rtv/templates')
-        self.callback_app.listen(65000)
 
     def get_config_fp(self):
         HOME = os.path.expanduser('~')
@@ -111,6 +110,9 @@ class OAuthTool(object):
         self.open_config(update=True)
         # If no previous OAuth data found, starting from scratch
         if not self.config.has_section('oauth') or not self.config.has_option('oauth', 'refresh_token'):
+            # Start HTTP server and listen on port 65000
+            self.callback_app.listen(65000)
+            
             # Generate a random UUID
             hex_uuid = uuid.uuid4().hex
 

--- a/rtv/oauth.py
+++ b/rtv/oauth.py
@@ -94,6 +94,12 @@ class OAuthTool(object):
         with open(self.config_fp, 'w') as cfg:
             self.config.write(cfg)
 
+    def clear_oauth_data(self):
+        self.open_config(update=True)
+        if self.config.has_section('oauth') and self.config.has_option('oauth', 'refresh_token'):
+            self.config.remove_option('oauth', 'refresh_token')
+            self.save_config()
+
     def authorize(self):
         if self.compact and not '.compact' in self.reddit.config.API_PATHS['authorize']:
             self.reddit.config.API_PATHS['authorize'] += '.compact'

--- a/rtv/oauth.py
+++ b/rtv/oauth.py
@@ -11,7 +11,8 @@ from six.moves import configparser
 from . import config
 from .curses_helpers import show_notification, prompt_input
 
-from tornado import ioloop, web
+from tornado import gen, ioloop, web
+from concurrent.futures import ThreadPoolExecutor
 
 __all__ = ['token_validity', 'OAuthTool']
 _logger = logging.getLogger(__name__)
@@ -28,18 +29,15 @@ class HomeHandler(web.RequestHandler):
 class AuthHandler(web.RequestHandler):
 
     def get(self):
-        try:
-            global oauth_state
-            global oauth_code
-            global oauth_error
+        global oauth_state
+        global oauth_code
+        global oauth_error
 
-            oauth_state = self.get_argument('state', default='state_placeholder')
-            oauth_code = self.get_argument('code', default='code_placeholder')
-            oauth_error = self.get_argument('error', default='error_placeholder')
+        oauth_state = self.get_argument('state', default='state_placeholder')
+        oauth_code = self.get_argument('code', default='code_placeholder')
+        oauth_error = self.get_argument('error', default='error_placeholder')
 
-            self.render('auth.html', state=oauth_state, code=oauth_code, error=oauth_error)
-        finally:
-            ioloop.IOLoop.current().stop()
+        self.render('auth.html', state=oauth_state, code=oauth_code, error=oauth_error)
 
 class OAuthTool(object):
 
@@ -99,6 +97,13 @@ class OAuthTool(object):
             self.config.remove_option('oauth', 'refresh_token')
             self.save_config()
 
+    @gen.coroutine
+    def open_terminal_browser(self, url):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            yield executor.submit(webbrowser.open_new_tab, url)
+
+        ioloop.IOLoop.current().stop()
+
     def authorize(self):
         if self.compact and not '.compact' in self.reddit.config.API_PATHS['authorize']:
             self.reddit.config.API_PATHS['authorize'] += '.compact'
@@ -112,7 +117,7 @@ class OAuthTool(object):
         if not self.config.has_section('oauth') or not self.config.has_option('oauth', 'refresh_token'):
             # Start HTTP server and listen on port 65000
             self.callback_app.listen(65000)
-            
+
             # Generate a random UUID
             hex_uuid = uuid.uuid4().hex
 
@@ -122,7 +127,7 @@ class OAuthTool(object):
             if self.compact:
                 show_notification(self.stdscr, ['Opening ' + os.environ.get('BROWSER')])
                 curses.endwin()
-                webbrowser.open_new_tab(permission_ask_page_link)
+                ioloop.IOLoop.current().add_callback(self.open_terminal_browser, permission_ask_page_link)
                 ioloop.IOLoop.current().start()
                 curses.doupdate()
             else:

--- a/rtv/oauth.py
+++ b/rtv/oauth.py
@@ -28,17 +28,18 @@ class HomeHandler(web.RequestHandler):
 class AuthHandler(web.RequestHandler):
 
     def get(self):
-        global oauth_state
-        global oauth_code
-        global oauth_error
+        try:
+            global oauth_state
+            global oauth_code
+            global oauth_error
 
-        oauth_state = self.get_argument('state', default='state_placeholder')
-        oauth_code = self.get_argument('code', default='code_placeholder')
-        oauth_error = self.get_argument('error', default='error_placeholder')
+            oauth_state = self.get_argument('state', default='state_placeholder')
+            oauth_code = self.get_argument('code', default='code_placeholder')
+            oauth_error = self.get_argument('error', default='error_placeholder')
 
-        self.render('auth.html', state=oauth_state, code=oauth_code, error=oauth_error)
-
-        ioloop.IOLoop.current().stop()
+            self.render('auth.html', state=oauth_state, code=oauth_code, error=oauth_error)
+        finally:
+            ioloop.IOLoop.current().stop()
 
 class OAuthTool(object):
 

--- a/rtv/page.py
+++ b/rtv/page.py
@@ -352,6 +352,7 @@ class BasePage(object):
 
         if self.reddit.is_oauth_session():
             self.reddit.clear_authentication()
+            self.oauth.clear_oauth_data()
             return
 
         self.oauth.authorize()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,14 @@
 from setuptools import setup
 from version import __version__ as version
 
+import sys
+
+requirements = ['tornado', 'praw>=3.1.0', 'six', 'requests', 'kitchen']
+
+# Python 2: add required concurrent.futures backport from Python 3.2
+if sys.version_info.major <= 2:
+    requirements.append('futures')
+
 setup(
     name='rtv',
     version=version,
@@ -13,7 +21,7 @@ setup(
     keywords='reddit terminal praw curses',
     packages=['rtv'],
     include_package_data=True,
-    install_requires=['tornado', 'praw>=3.1.0', 'six', 'requests', 'kitchen'],
+    install_requires=requirements,
     entry_points={'console_scripts': ['rtv=rtv.__main__:main']},
     classifiers=[
         'Intended Audience :: End Users/Desktop',


### PR DESCRIPTION
Hey, I finished implementing terminal web browser support. It was much easier with ``curses.endwin()`` and ``curses.doupdate()``. I had looked Python Curses documentation, but I guess I couldn't figure ``curses.doupdate()`` would set screen back up, maybe because the documentation was not very explicit about it. Anyway, it is working now, and much cleaner than my previous attempt. :)