### PR TITLE
Make loads interruptible and some more small things.

### DIFF
--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -63,7 +63,8 @@ def main():
         print('Connecting...')
         reddit = praw.Reddit(user_agent=AGENT.format(version=__version__))
         reddit.config.decode_html_entities = False
-        with curses_session() as stdscr:
+
+        def loop(stdscr):
             oauth = OAuthTool(reddit, stdscr, LoadScreen(stdscr))
             if oauth.refresh_token:
                 oauth.authorize()
@@ -71,8 +72,11 @@ def main():
             if args.link:
                 page = SubmissionPage(stdscr, reddit, oauth, url=args.link)
                 page.loop()
+
             page = SubredditPage(stdscr, reddit, oauth, args.subreddit)
             page.loop()
+
+        curses_session(loop)
     except (praw.errors.OAuthAppRequired, praw.errors.OAuthInvalidToken):
         print('Invalid OAuth data')
     except praw.errors.NotFound:

--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -2,6 +2,7 @@ import os
 import sys
 import locale
 import logging
+import signal
 
 import requests
 import praw
@@ -10,7 +11,7 @@ import tornado
 
 from . import config
 from .exceptions import SubmissionError, SubredditError, SubscriptionError, ProgramError
-from .curses_helpers import curses_session, LoadScreen
+from .curses_helpers import curses_session, KeyboardInterruptible, LoadScreen
 from .submission import SubmissionPage
 from .subreddit import SubredditPage
 from .docs import AGENT
@@ -63,20 +64,24 @@ def main():
         print('Connecting...')
         reddit = praw.Reddit(user_agent=AGENT.format(version=__version__))
         reddit.config.decode_html_entities = False
+        KeyboardInterruptible.ignore_interrupt()
 
         def loop(stdscr):
             oauth = OAuthTool(reddit, stdscr, LoadScreen(stdscr))
             if oauth.refresh_token:
                 oauth.authorize()
 
-            if args.link:
-                page = SubmissionPage(stdscr, reddit, oauth, url=args.link)
+            with KeyboardInterruptible(stdscr) as k:
+                if args.link:
+                    page = SubmissionPage(stdscr, reddit, oauth, url=args.link)
+                else:
+                    page = SubredditPage(stdscr, reddit, oauth, args.subreddit)
+                k.disable()
                 page.loop()
 
-            page = SubredditPage(stdscr, reddit, oauth, args.subreddit)
-            page.loop()
-
         curses_session(loop)
+    except requests.exceptions.RequestException:
+        print('Request failed')
     except (praw.errors.OAuthAppRequired, praw.errors.OAuthInvalidToken):
         print('Invalid OAuth data')
     except praw.errors.NotFound:
@@ -90,8 +95,6 @@ def main():
     except ProgramError as e:
         print('Error: could not open file with program "{}", '
               'try setting RTV_EDITOR'.format(e.name))
-    except KeyboardInterrupt:
-        pass
     finally:
         # Ensure sockets are closed to prevent a ResourceWarning
         reddit.handler.http.close()

--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -71,8 +71,7 @@ def main():
             if args.link:
                 page = SubmissionPage(stdscr, reddit, oauth, url=args.link)
                 page.loop()
-            subreddit = args.subreddit or 'front'
-            page = SubredditPage(stdscr, reddit, oauth, subreddit)
+            page = SubredditPage(stdscr, reddit, oauth, args.subreddit)
             page.loop()
     except (praw.errors.OAuthAppRequired, praw.errors.OAuthInvalidToken):
         print('Invalid OAuth data')

--- a/rtv/config.py
+++ b/rtv/config.py
@@ -32,7 +32,7 @@ def build_parser():
         '-V', '--version', action='version', version='rtv '+__version__,
     )
     parser.add_argument(
-        '-s', dest='subreddit',
+        '-s', dest='subreddit', default='front',
         help='name of the subreddit that will be opened on start')
     parser.add_argument(
         '-l', dest='link',

--- a/rtv/config.py
+++ b/rtv/config.py
@@ -57,20 +57,16 @@ def load_config():
     """
 
     config = configparser.ConfigParser()
-    if os.path.exists(CONFIG):
-        config.read(CONFIG)
+    config.read(CONFIG)
 
     config_dict = {}
     if config.has_section('rtv'):
         config_dict = dict(config.items('rtv'))
 
     # Convert 'true'/'false' to boolean True/False
-    if 'ascii' in config_dict:
-        config_dict['ascii'] = config.getboolean('rtv', 'ascii')
-    if 'clear_auth' in config_dict:
-        config_dict['clear_auth'] = config.getboolean('rtv', 'clear_auth')
-    if 'persistent' in config_dict:
-        config_dict['persistent'] = config.getboolean('rtv', 'persistent')
+    for name in ['ascii', 'clear_auth', 'persistent']:
+        if name in config_dict:
+            config_dict[name] = config.getboolean('rtv', name)
 
     return config_dict
 
@@ -78,8 +74,6 @@ def load_refresh_token(filename=TOKEN):
     if os.path.exists(filename):
         with open(filename) as fp:
             return fp.read().strip()
-    else:
-        return None
 
 def save_refresh_token(token, filename=TOKEN):
     with open(filename, 'w+') as fp:

--- a/rtv/curses_helpers.py
+++ b/rtv/curses_helpers.py
@@ -318,55 +318,26 @@ def prompt_input(window, prompt, hide=False):
     return out
 
 
-@contextmanager
-def curses_session():
+def curses_session(func):
     """
     Setup terminal and initialize curses.
     """
 
-    try:
-        # Curses must wait for some time after the Escape key is pressed to
-        # check if it is the beginning of an escape sequence indicating a
-        # special key. The default wait time is 1 second, which means that
-        # getch() will not return the escape key (27) until a full second
-        # after it has been pressed.
-        # Turn this down to 25 ms, which is close to what VIM uses.
-        # http://stackoverflow.com/questions/27372068
-        os.environ['ESCDELAY'] = '25'
+    # Curses must wait for some time after the Escape key is pressed to
+    # check if it is the beginning of an escape sequence indicating a
+    # special key. The default wait time is 1 second, which means that
+    # getch() will not return the escape key (27) until a full second
+    # after it has been pressed.
+    # Turn this down to 25 ms, which is close to what VIM uses.
+    # http://stackoverflow.com/questions/27372068
+    os.environ['ESCDELAY'] = '25'
 
-        # Initialize curses
-        stdscr = curses.initscr()
-
-        # Turn off echoing of keys, and enter cbreak mode,
-        # where no buffering is performed on keyboard input
-        curses.noecho()
-        curses.cbreak()
-
-        # In keypad mode, escape sequences for special keys
-        # (like the cursor keys) will be interpreted and
-        # a special value like curses.KEY_LEFT will be returned
-        stdscr.keypad(1)
-
-        # Start color, too.  Harmless if the terminal doesn't have
-        # color; user can test with has_color() later on.  The try/catch
-        # works around a minor bit of over-conscientiousness in the curses
-        # module -- the error return from C start_color() is ignorable.
-        try:
-            curses.start_color()
-        except:
-            pass
-
+    def inner(stdscr):
         Color.init()
 
         # Hide blinking cursor
         curses.curs_set(0)
 
-        yield stdscr
+        func(stdscr)
 
-    finally:
-
-        if stdscr is not None:
-            stdscr.keypad(0)
-            curses.echo()
-            curses.nocbreak()
-            curses.endwin()
+    curses.wrapper(inner)

--- a/rtv/curses_helpers.py
+++ b/rtv/curses_helpers.py
@@ -79,12 +79,15 @@ def add_line(window, text, row=None, col=None, attr=None):
     window.addstr(row, col, text, *params)
 
 
-def show_notification(stdscr, message):
+def show_notification(stdscr, message, delay=0):
     """
-    Overlay a message box on the center of the screen and wait for user input.
+    Overlay a message box on the center of the screen and wait for user input
+    or sleep for fixed number of seconds.
 
     Params:
         message (list): List of strings, one per line.
+        delay (float): If set to zero, wait for keypress, else specifies
+                       number of seconds to sleep before returning.
     """
 
     n_rows, n_cols = stdscr.getmaxyx()
@@ -107,13 +110,14 @@ def show_notification(stdscr, message):
     for index, line in enumerate(message, start=1):
         add_line(window, line, index, 1)
     window.refresh()
-    ch = stdscr.getch()
+    if delay == 0:
+        stdscr.getch()
+    else:
+        time.sleep(delay)
 
     window.clear()
     window = None
     stdscr.refresh()
-
-    return ch
 
 
 def show_help(stdscr):

--- a/rtv/page.py
+++ b/rtv/page.py
@@ -9,8 +9,8 @@ import requests
 from kitchen.text.display import textual_width
 
 from .helpers import open_editor
-from .curses_helpers import (Color, show_notification, show_help, prompt_input,
-                             add_line)
+from .curses_helpers import (Color, KeyboardInterruptible, show_notification,
+                             show_help, prompt_input, add_line)
 from .docs import COMMENT_EDIT_FILE, SUBMISSION_FILE
 
 __all__ = ['Navigator', 'BaseController', 'BasePage']
@@ -149,10 +149,9 @@ class Navigator(object):
 
         try:
             self._page_cb(page_index)
+            return True
         except IndexError:
             return False
-        else:
-            return True
 
 
 class SafeCaller(object):
@@ -474,6 +473,10 @@ class BasePage(object):
             #>>>     on_success()
         """
         return SafeCaller(self.stdscr)
+
+    @property
+    def keyboard_interruptible(self):
+        return KeyboardInterruptible(self.stdscr)
 
     def draw(self):
 

--- a/rtv/subreddit.py
+++ b/rtv/subreddit.py
@@ -105,11 +105,14 @@ class SubredditPage(BasePage):
         "Select the current submission to view posts"
 
         data = self.content.get(self.nav.absolute_index)
-        page = SubmissionPage(self.stdscr, self.reddit, self.oauth, url=data['permalink'])
-        page.loop()
-        if data['url_type'] == 'selfpost':
-            global history
-            history.add(data['url_full'])
+
+        with self.keyboard_interruptible as k:
+            page = SubmissionPage(self.stdscr, self.reddit, self.oauth, url=data['permalink'])
+            k.disable()
+            page.loop()
+            if data['url_type'] == 'selfpost':
+                global history
+                history.add(data['url_full'])
 
     @SubredditController.register(curses.KEY_ENTER, 10, 'o')
     def open_link(self):
@@ -120,8 +123,10 @@ class SubredditPage(BasePage):
         global history
         history.add(url)
         if data['url_type'] in ['x-post', 'selfpost']:
-            page = SubmissionPage(self.stdscr, self.reddit, self.oauth, url=url)
-            page.loop()
+            with self.keyboard_interruptible as k:
+                page = SubmissionPage(self.stdscr, self.reddit, self.oauth, url=url)
+                k.disable()
+                page.loop()
         else:
             open_browser(url)
 


### PR DESCRIPTION
Hi, this adds one feature I'm missing, the ability to cancel loads (because bad network etc.). It's similar to the `safe_call` mechanism, except it responds to <kbd>Ctrl-C</kbd>/`SIGINT` during blocking loads (while "Downloading..." shows). I haven't *yet* annotated all instances of these (mostly because I'd have to find them first), but the initial download, the comment thread and the "more comments" fields have been changed.

The other commits are more cleanups, although I noticed that `curses.wrapper` was initially used, but then rewritten into `curses_session`; I'm not sure why, so I included this proposal to reduce the lines of code again.

I'm happy to restructure this if doesn't look good so far, but I also want early feedback if this is even wanted. Btw. is there a common location for chat/discussion so far, except in the issues tracker?