### PR TITLE
After update to version 1.6.1 Exception UnicodeEncodeError closes the application

### DIFF
--- a/rtv/content.py
+++ b/rtv/content.py
@@ -138,7 +138,7 @@ class BaseContent(object):
         data['index'] = None  # This is filled in later by the method caller
 
         if data['flair'] and not data['flair'].startswith('['):
-            data['flair'] = '[{}]'.format(data['flair'].strip())
+            data['flair'] = u'[{}]'.format(data['flair'].strip())
 
         url_full = data['url_full']
         if data['permalink'].split('/r/')[-1] == url_full.split('/r/')[-1]:


### PR DESCRIPTION
Any SUBREDDIT with special characters like u'\xe3' are triggering an error at line 141, data['flair'] = '[{}]'.format(data['flair'].strip()) .
The solution was to add u'[{}]' to the concatenation.
The original error message: UnicodeEncodeError: 'ascii' codec can't encode character u'\xe3' in position 7: ordinal not in range(128) .