### PR TITLE
Feature: View and save posts/comments #180

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,7 @@ The ``/`` prompt accepts subreddits in the following formats
 * ``/r/python+linux`` supports multireddits
 * ``/r/front`` will redirect to the front page
 * ``/r/me`` will display your submissions
+* ``/r/saved`` will display your saved posts/comments
 
 ---------------
 Submission Mode

--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,7 @@ Once you are logged in your username will appear in the top-right corner of the 
 :``d``: Delete an existing post or comment
 :``i``: Display new messages prompt
 :``s``: View a list of subscribed subreddits
+:``y``: View a list of your saved posts
 
 --------------
 Subreddit Mode

--- a/rtv/content.py
+++ b/rtv/content.py
@@ -455,7 +455,10 @@ class SubredditContent(Content):
             else:
                 # TODO: In order to display saved comment, we need to
                 # coerce the comment into a submission
-                data = self.strip_praw_submission(submission)
+                try:
+                    data = self.strip_praw_submission(submission)
+                except:
+                    continue
                 data['index'] = index
                 # Add the post number to the beginning of the title
                 data['title'] = '{0}. {1}'.format(index+1, data.get('title'))

--- a/rtv/submission.py
+++ b/rtv/submission.py
@@ -24,7 +24,6 @@ class SubmissionPage(Page):
             self.content = SubmissionContent.from_url(reddit, url, term.loader)
         else:
             self.content = SubmissionContent(submission, term.loader)
-
         self.controller = SubmissionController(self)
         # Start at the submission post, which is indexed as -1
         self.nav = Navigator(self.content.get, page_index=-1)
@@ -70,6 +69,14 @@ class SubmissionPage(Page):
             self.term.open_browser(url)
         else:
             self.term.flash()
+
+    @SubmissionController.register('y')
+    @logged_in
+    def save_comment(self):
+        comment = self.content.get(self.nav.absolute_index).get('object')
+        if comment:
+            with self.term.loader('Saving comment'):
+                comment.save()
 
     @SubmissionController.register('c')
     @logged_in
@@ -167,6 +174,10 @@ class SubmissionPage(Page):
                 text, attr = self.term.stickied
                 self.term.add_line(win, text, attr=attr)
 
+            if data['saved']:
+                text, attr = 'SAVED', (curses.A_BOLD | Color.BLUE)
+                self.term.add_line(win, text, attr=attr)
+
         for row, text in enumerate(data['split_body'], start=offset+1):
             if row in valid_rows:
                 self.term.add_line(win, text, row, 1)
@@ -236,6 +247,10 @@ class SubmissionPage(Page):
 
         if data['nsfw']:
             text, attr = 'NSFW', (curses.A_BOLD | Color.RED)
+            self.term.add_line(win, text, attr=attr)
+
+        if data['saved']:
+            text, attr = 'SAVED', (curses.A_BOLD | Color.RED)
             self.term.add_line(win, text, attr=attr)
 
         win.border()

--- a/rtv/subreddit.py
+++ b/rtv/subreddit.py
@@ -145,6 +145,16 @@ class SubredditPage(Page):
 
         self.refresh_content()
 
+    @SubredditController.register('y')
+    @logged_in
+    def save_submition(self):
+        data = self.content.get(self.nav.absolute_index)
+        url = data['permalink']
+        with self.term.loader('Saving submission'):
+            page = SubmissionPage(
+                self.reddit, self.term, self.config, self.oauth, url=url)
+            page.content.save()
+
     @SubredditController.register('s')
     @logged_in
     def open_subscriptions(self):
@@ -201,6 +211,10 @@ class SubredditPage(Page):
 
             if data['nsfw']:
                 text, attr = 'NSFW', (curses.A_BOLD | Color.RED)
+                self.term.add_line(win, text, attr=attr)
+
+            if data['saved']:
+                text, attr = ' SAVED', (curses.A_BOLD | Color.BLUE)
                 self.term.add_line(win, text, attr=attr)
 
         row = n_title + offset + 2


### PR DESCRIPTION
Code from issue #180.

This PR allows for users to type `/saved` in the subreddit prompt and view their saved posts. This DOES NOT address saved comments due to the nature of displaying comments as posts. I will add that feature next with some guidance from @michael-lazar.

You can also type `y` on a post or a comment to save it to your authenticated user. It will also add a label to the post. Currently the label will be applied on the next load. I'm not sure the best way to handle this? Should it refresh immediately or wait for the user to do a refresh?

Please let me know if there are any issues, thanks!