### PR TITLE
Automatic viewer

### DIFF
--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -88,7 +88,7 @@ def main():
             if not config['monochrome']:
                 Color.init()
 
-            term = Terminal(stdscr, config=config, ascii=config['ascii'])
+            term = Terminal(stdscr, config)
             with term.loader('Initializing', catch_exception=False):
                 reddit = praw.Reddit(user_agent=user_agent,
                                      decode_html_entities=False,

--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -88,7 +88,7 @@ def main():
             if not config['monochrome']:
                 Color.init()
 
-            term = Terminal(stdscr, config)
+            term = Terminal(stdscr, config=config, ascii=config['ascii'])
             with term.loader('Initializing', catch_exception=False):
                 reddit = praw.Reddit(user_agent=user_agent,
                                      decode_html_entities=False,

--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -88,7 +88,7 @@ def main():
             if not config['monochrome']:
                 Color.init()
 
-            term = Terminal(stdscr, config['ascii'])
+            term = Terminal(stdscr, config)
             with term.loader('Initializing', catch_exception=False):
                 reddit = praw.Reddit(user_agent=user_agent,
                                      decode_html_entities=False,

--- a/rtv/rtv.cfg
+++ b/rtv/rtv.cfg
@@ -34,9 +34,6 @@ clear_auth = False
 ; Maximum number of opened links that will be saved in the history file.
 history_size = 200
 
-; Default image view
-image_view = feh -Z
-
 ################
 # OAuth Settings
 ################

--- a/rtv/rtv.cfg
+++ b/rtv/rtv.cfg
@@ -34,6 +34,9 @@ clear_auth = False
 ; Maximum number of opened links that will be saved in the history file.
 history_size = 200
 
+; Default image view
+image_view = feh -Z
+
 ################
 # OAuth Settings
 ################

--- a/rtv/submission.py
+++ b/rtv/submission.py
@@ -196,7 +196,7 @@ class SubmissionPage(Page):
                 text, attr = self.term.stickied
                 self.term.add_line(win, text, attr=attr)
 
-        for row, text in enumerate(split_body, start=offset+1):
+        for row, text in enumerate(split_body, start=offset + 1):
             if row in valid_rows:
                 self.term.add_line(win, text, row, 1)
 
@@ -215,7 +215,8 @@ class SubmissionPage(Page):
         n_cols -= 1
 
         self.term.add_line(win, '{body}'.format(**data), 0, 1)
-        self.term.add_line(win, ' [{count}]'.format(**data), attr=curses.A_BOLD)
+        self.term.add_line(win, ' [{count}]'.format(
+            **data), attr=curses.A_BOLD)
 
         attr = Color.get_level(data['level'])
         self.term.addch(win, 0, 0, self.term.vline, attr)

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -37,11 +37,11 @@ class Terminal(object):
     RETURN = 10
     SPACE = 32
 
-    def __init__(self, stdscr, ascii, config=None):
+    def __init__(self, stdscr, config):
 
         self.stdscr = stdscr
         self.config = config
-        self.ascii = ascii
+        self.ascii = config['ascii']
         self.loader = LoadScreen(self)
         self._display = None
 

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -37,11 +37,11 @@ class Terminal(object):
     RETURN = 10
     SPACE = 32
 
-    def __init__(self, stdscr, config):
+    def __init__(self, stdscr, ascii, config=None):
 
         self.stdscr = stdscr
         self.config = config
-        self.ascii = config['ascii']
+        self.ascii = ascii
         self.loader = LoadScreen(self)
         self._display = None
 
@@ -310,10 +310,9 @@ class Terminal(object):
             command = self.config['image_view'].split() + [url]
             with self.loader('Opening page in a new window'), \
                     open(os.devnull, 'ab+', 0) as null:
-                p = subprocess.call(command, stdout=null, stderr=null)
+                return not subprocess.call(command, stdout=null, stderr=null)
         else:
             return False
-        return True
 
     def open_browser(self, url):
         """
@@ -346,7 +345,7 @@ class Terminal(object):
                 if self.open_image(url):
                     return
             except:
-                # FAiled to open local. Keep opening with browser
+                # Failed to open local. Keep opening with browser
                 pass
 
         if self.display:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ import setuptools
 
 from version import __version__ as version
 
-requirements = ['tornado', 'praw==3.4.0', 'six', 'requests', 'kitchen']
+requirements = ['tornado', 'praw==3.4.0',
+                'six', 'requests', 'kitchen', 'pyxdg']
 
 # Python 2: add required concurrent.futures backport from Python 3.2
 if sys.version_info.major <= 2:
@@ -37,5 +38,5 @@ setuptools.setup(
         'Topic :: Terminals',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Message Boards',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: News/Diary',
-        ],
+    ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,7 +173,7 @@ def reddit(vcr, request):
 
 @pytest.fixture()
 def terminal(stdscr, config):
-    term = Terminal(stdscr, ascii=config['ascii'])
+    term = Terminal(stdscr, config)
     # Disable the python 3.4 addch patch so that the mock stdscr calls are
     # always made the same way
     term.addch = lambda window, *args: window.addch(*args)

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -346,3 +346,23 @@ def test_open_pager(terminal, stdscr):
         terminal.open_pager(data)
         message = 'Could not open pager fake'.encode('ascii')
         assert stdscr.addstr.called_with(0, 0, message)
+
+
+@pytest.mark.xfail(reason="Some extensions may not have default application defined")
+def test_select_program(terminal):
+    urls = ['http://www.test.com/image.png',
+            'http://www.test.com/image.jpg',
+            'http://www.test.com/image.jpeg',
+            'http://www.test.com/image.gif',
+            'http://www.test.com/image.gifv']
+
+    # should be valid ones
+    for url in urls:
+        assert terminal.select_program(url)
+
+    # should return None
+    urls = ['http://www.test.com/not_image',
+            'http://www.test.com/not_image.html',
+            'not a valid url', ]
+    for url in urls:
+        assert not terminal.select_program(url)

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -291,6 +291,20 @@ def test_open_editor(terminal):
         assert curses.doupdate.called
 
 
+def test_open_image(terminal):
+
+    url = 'http://www.test.com/image.png'
+
+    terminal._display = True
+    terminal.config = {'image_view': 'echo'}
+    with mock.patch('subprocess.call', autospec=True) as call:
+        return_value = terminal.open_image(url)
+        assert not return_value
+
+    terminal._display = False
+    assert not terminal.open_image(url)
+
+
 def test_open_browser(terminal):
 
     url = 'http://www.test.com'

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -10,6 +10,7 @@ import pytest
 
 from rtv.docs import HELP, COMMENT_EDIT_FILE
 from rtv.objects import Color
+from rtv.terminal import Terminal
 
 try:
     from unittest import mock
@@ -291,6 +292,8 @@ def test_open_editor(terminal):
         assert curses.doupdate.called
 
 
+@pytest.mark.skipif(Terminal.select_program('http://www.test.com/image.png') == None,
+                    reason="PNG extension not have default program on travis")
 def test_open_image(terminal):
 
     url = 'http://www.test.com/image.png'


### PR DESCRIPTION
Whatever a link with a image (jpg, png, gif, jpeg, bmp) is clicked it will be checked if there is a local program configured to open the image instead the browser. If not defined or there isn't any, calls browser as default. Tests included, but Travis don't have a default program to `*.png` ¬¬.

**Notes:**
- Some PEP8 fixes into the original code.
- Tests updated to send `config` instead of `ascii`only.