### PR TITLE
Add an optional 'handlers' section to the config file for special han…

### DIFF
--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -40,12 +40,13 @@ def main():
     sys.stdout.write('\x1b]2;{0}\x07'.format(title))
 
     args = Config.get_args()
-    fargs, bindings = Config.get_file(args.get('config'))
+    fargs, bindings, handlers = Config.get_file(args.get('config'))
 
     # Apply the file config first, then overwrite with any command line args
     config = Config()
     config.update(**fargs)
     config.update(**args)
+    config.set_mime_handlers(handlers)
 
     # If key bindings are supplied in the config file, overwrite the defaults
     if bindings:
@@ -88,7 +89,7 @@ def main():
             if not config['monochrome']:
                 Color.init()
 
-            term = Terminal(stdscr, config['ascii'])
+            term = Terminal(stdscr, config)
             with term.loader('Initializing', catch_exception=False):
                 reddit = praw.Reddit(user_agent=user_agent,
                                      decode_html_entities=False,

--- a/rtv/config.py
+++ b/rtv/config.py
@@ -123,6 +123,7 @@ class Config(object):
         default, bindings, handlers = self.get_file(DEFAULT_CONFIG)
         self.default = default
         self.keymap = KeyMap(bindings)
+        self.set_mime_handlers(handlers)
 
         # `refresh_token` and `history` are saved/loaded at separate locations,
         # so they are treated differently from the rest of the config options.

--- a/rtv/config.py
+++ b/rtv/config.py
@@ -6,11 +6,13 @@ import codecs
 import shutil
 import argparse
 from functools import partial
+from importlib import import_module
 
 import six
 from six.moves import configparser
 
 from . import docs, __version__
+from .exceptions import ConfigError
 from .objects import KeyMap
 
 PACKAGE = os.path.dirname(__file__)
@@ -118,7 +120,7 @@ class Config(object):
         self.token_file = token_file
         self.config = kwargs
 
-        default, bindings = self.get_file(DEFAULT_CONFIG)
+        default, bindings, handlers = self.get_file(DEFAULT_CONFIG)
         self.default = default
         self.keymap = KeyMap(bindings)
 
@@ -126,6 +128,25 @@ class Config(object):
         # so they are treated differently from the rest of the config options.
         self.refresh_token = None
         self.history = OrderedSet()
+
+    def set_mime_handlers(self, mime_handler_mapping):
+        handlers = {}
+        for mimetype in mime_handler_mapping:
+            handler_name = mime_handler_mapping[mimetype]
+            try:
+                module_name, func_name = handler_name.rsplit('.', 1)
+                module = import_module(module_name)
+            except ImportError:
+                raise ConfigError(
+                    'failed to import handler for mimetype %s: %s'
+                    % (mimetype, handler_name))
+            try:
+                handlers[mimetype] = getattr(module, func_name)
+            except AttributeError:
+                raise ConfigError(
+                    'no such handler for mimetype %s named %s in module %s.'
+                    % (mimetype, func_name, module_name))
+        self.handlers = handlers
 
     def __getitem__(self, item):
         if item in self.config:
@@ -230,7 +251,18 @@ class Config(object):
         for name, keys in bindings.items():
             bindings[name] = [key.strip() for key in keys.split(',')]
 
-        return rtv, bindings
+        handlers = {}
+        if config.has_section('handlers'):
+            for handler_name, types in config.items('handlers'):
+                for t in types.split(','):
+                    t = t.strip()
+                    if t in handlers:
+                        raise ConfigError(
+                            'Duplicate handlers for same mimetype %s: %s, %s'
+                            % (t, handlers[t], handler_name))
+                    handlers[t] = handler_name
+
+        return rtv, bindings, handlers
 
     @staticmethod
     def _ensure_filepath(filename):

--- a/rtv/mime_handlers.py
+++ b/rtv/mime_handlers.py
@@ -1,0 +1,64 @@
+"""Special handlers for displaying data with certain mimetypes."""
+
+import base64
+import os
+import time
+
+import requests
+
+
+def iterm2_image_viewer(terminal, link):
+    """Display an image inline with iTerm2 version 3+."""
+    height, width = terminal.stdscr.getmaxyx()
+
+    def encode_image(data):
+        # This is based on the iTerm2 imgcat script:
+        # https://raw.githubusercontent.com/gnachman/iTerm2/master/tests/imgcat
+        is_tmux = os.getenv('TERM', '').startswith('screen')
+        encoded_data = base64.b64encode(data)
+
+        imgseq = [b'\033Ptmux;\033\033]' if is_tmux else b'\033]']
+        imgseq.append(b'1337;File=')
+        imgseq.append(b'width=' + str(width).encode())
+        # Save some room for extra information at the bottom.
+        imgseq.append(b';height=' + str(height - 2).encode())
+        imgseq.append(b";preserveAspectRatio=true;inline=1:")
+        imgseq.append(encoded_data)
+        imgseq.append(b'\a\033\\' if is_tmux else b'\a')
+        return b''.join(imgseq)
+
+    with terminal.loader('Downloading image'):
+        req = requests.get(link, stream=True)
+        if req.status_code != 200:
+            terminal.show_notification(
+                'Failed to download image. Status code = %d' % req.status_code)
+            return
+
+        req.raw.decode_content = True
+        image_data = encode_image(req.raw.read())
+
+    # Create a new blank window that takes up the whole screen.
+    win = terminal.stdscr.derwin(height, width, 0, 0)
+    win.erase()
+    win.refresh()
+    # Curses doesn't seem to be able to handle this data for some reason.
+    # Use print() to overlay on window.
+    print(image_data.decode('utf-8'))
+    # We resized the image to make sure there's room for this.
+    win.addstr(height - 2, 0, 'url: %s' % link)
+    win.addstr(height - 1, 0, 'press any key to continue...')
+    terminal.stdscr.touchwin()
+    terminal.stdscr.refresh()
+
+    # Wait for a keypress.
+    while True:
+        if terminal.getch() != -1:
+            break
+        time.sleep(0.01)
+
+    # Clear the whole screen again.
+    win.clear()
+    win.refresh()
+    del win
+    terminal.stdscr.touchwin()
+    terminal.stdscr.refresh()

--- a/rtv/rtv.cfg
+++ b/rtv/rtv.cfg
@@ -124,3 +124,15 @@ SUBREDDIT_OPEN_SUBSCRIPTIONS = s
 ; Subscription page
 SUBSCRIPTION_SELECT = l, <LF>, <KEY_ENTER>, <KEY_RIGHT>
 SUBSCRIPTION_EXIT = h, s, <ESC>, <KEY_LEFT>
+
+###################
+# Mimetype Handlers
+###################
+[handlers]
+
+; In this section, you can name functions to call when handling certain
+; mimetypes. For example, you could run a Python function for viewing
+; an image or listening to audio without leaving the terminal.
+
+; Special handler to open images (view inline when using iTerm2 version 3+).
+; rtv.mime_handlers.iterm2_image_viewer = image/jpeg,image/jpg,image/png,image/gif

--- a/rtv/submission.py
+++ b/rtv/submission.py
@@ -73,7 +73,7 @@ class SubmissionPage(Page):
         data = self.content.get(self.nav.absolute_index)
         url = data.get('permalink')
         if url:
-            self.term.open_browser(url)
+            self.term.open_link(url)
         else:
             self.term.flash()
 

--- a/rtv/subreddit.py
+++ b/rtv/subreddit.py
@@ -103,7 +103,7 @@ class SubredditPage(Page):
             self.open_submission(url=data['url_full'])
             self.config.history.add(data['url_full'])
         else:
-            self.term.open_browser(data['url_full'])
+            self.term.open_link(data['url_full'])
             self.config.history.add(data['url_full'])
 
     @SubredditController.register(Command('SUBREDDIT_POST'))

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -6,6 +6,7 @@ import sys
 import time
 import codecs
 import curses
+import mimetypes
 import webbrowser
 import subprocess
 import curses.ascii
@@ -37,10 +38,11 @@ class Terminal(object):
     RETURN = 10
     SPACE = 32
 
-    def __init__(self, stdscr, ascii=False):
+    def __init__(self, stdscr, config):
 
         self.stdscr = stdscr
-        self.ascii = ascii
+        self.config = config
+        self.ascii = self.config['ascii']
         self.loader = LoadScreen(self)
         self._display = None
 
@@ -298,6 +300,16 @@ class Terminal(object):
         self.stdscr.refresh()
 
         return ch
+
+    def open_link(self, link):
+        """Open a link with the appropriate handler."""
+        mimetype, _ = mimetypes.guess_type(link)
+        handler = self.config.handlers.get(mimetype)
+        if handler is None:
+            # Fall back to browser.
+            self.open_browser(link)
+        else:
+            handler(self, link)
 
     def open_browser(self, url):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,7 +173,7 @@ def reddit(vcr, request):
 
 @pytest.fixture()
 def terminal(stdscr, config):
-    term = Terminal(stdscr, ascii=config['ascii'])
+    term = Terminal(stdscr, config)
     # Disable the python 3.4 addch patch so that the mock stdscr calls are
     # always made the same way
     term.addch = lambda window, *args: window.addch(*args)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,11 +97,13 @@ def test_config_from_file():
 
     with NamedTemporaryFile(suffix='.cfg') as fp:
 
-        fargs, fbindings = Config.get_file(filename=fp.name)
+        fargs, fbindings, handlers = Config.get_file(filename=fp.name)
         config = Config(**fargs)
         config.keymap.set_bindings(fbindings)
+        config.set_mime_handlers(handlers)
         assert config.config == {}
         assert config.keymap._keymap == {}
+        assert config.handlers == {}
 
         # [rtv]
         rows = ['{0}={1}'.format(key, val) for key, val in args.items()]
@@ -114,12 +116,14 @@ def test_config_from_file():
         fp.write(codecs.encode(data, 'utf-8'))
 
         fp.flush()
-        fargs, fbindings = Config.get_file(filename=fp.name)
+        fargs, fbindings, handlers = Config.get_file(filename=fp.name)
         config.update(**fargs)
         config.keymap.set_bindings(fbindings)
+        config.set_mime_handlers(handlers)
         assert config.config == args
         assert config.keymap.get('REFRESH') == ['r', '<KEY_F5>']
         assert config.keymap.get('UPVOTE') == ['']
+        assert config.handlers == {}
 
 
 def test_config_refresh_token():


### PR DESCRIPTION
…dling of certain mimetypes.

I can clean this up any way you prefer; I just wanted to gauge interest in this feature first.

**Inspiration**
iTerm (terminal emulator I use on my mac) recently gained the ability to display images directly in the terminal: http://iterm2.com/documentation-images.html. I thought, why not make this available in RTV?

**Configuration**
Something like this goes into your rtv.cfg:

    [handlers]
    ; Special handler to open images.
    ; <handler name> = <list-of-mimetypes>
    rtv.mime_handlers.iterm2_image_viewer = image/jpeg,image/jpg,image/png,image/gif

**Results**

<img width="1567" alt="bildschirmfoto 2016-06-12 um 16 59 03" src="https://cloud.githubusercontent.com/assets/5168837/15994679/cfdabedc-30bf-11e6-9e21-c264ff244911.png">
<img width="1550" alt="bildschirmfoto 2016-06-12 um 16 58 59" src="https://cloud.githubusercontent.com/assets/5168837/15994681/d848eecc-30bf-11e6-9f70-2451b615f537.png">


This isn't just about images, though. This allows users to handle different mimetypes with python functions from RTV. I could also imagine a function to handle audio without leaving the terminal, for example. Also, as long as the function is importable, rtv can use it. It doesn't have to be defined in rtv's own source code.

Hope someone else finds this hack interesting/useful. Let me know if you think something needs to be cleaned up/changed.