### PR TITLE
allow more recent update-checker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ mailcap-fix==0.1.3
 praw==3.5.0
 requests==2.11.0
 six==1.10.0
-update-checker==0.11
+update-checker>=0.11


### PR DESCRIPTION
is there any reason why you have hardcoded 0.11? usually this is bad practice, and rtv seems to be working fine with 0.12 as well.