### PR TITLE
Setting the maximum comment column width

### DIFF
--- a/rtv/config.py
+++ b/rtv/config.py
@@ -67,6 +67,9 @@ def build_parser():
     parser.add_argument(
         '--enable-media', dest='enable_media', action='store_const', const=True,
         help='Open external links using programs defined in the mailcap config')
+    parser.add_argument(
+        '--max-comment-cols', dest='max_comment_cols', type=int,
+        help='Maximum comment column width')
     return parser
 
 
@@ -240,8 +243,10 @@ class Config(object):
             'enable_media': partial(config.getboolean, 'rtv'),
             'history_size': partial(config.getint, 'rtv'),
             'oauth_redirect_port': partial(config.getint, 'rtv'),
-            'oauth_scope': lambda x: rtv[x].split(',')
+            'oauth_scope': lambda x: rtv[x].split(','),
+            'max_comment_cols': partial(config.getint, 'rtv')
         }
+
         for key, func in params.items():
             if key in rtv:
                 rtv[key] = func(key)

--- a/rtv/config.py
+++ b/rtv/config.py
@@ -67,9 +67,6 @@ def build_parser():
     parser.add_argument(
         '--enable-media', dest='enable_media', action='store_const', const=True,
         help='Open external links using programs defined in the mailcap config')
-    parser.add_argument(
-        '--max-comment-cols', dest='max_comment_cols', type=int,
-        help='Maximum comment column width')
     return parser
 
 

--- a/rtv/content.py
+++ b/rtv/content.py
@@ -295,7 +295,7 @@ class SubmissionContent(Content):
     """
 
     def __init__(self, submission, loader, indent_size=2, max_indent_level=8,
-                 order=None, max_comment_cols=70):
+                 order=None, max_comment_cols=80):
 
         submission_data = self.strip_praw_submission(submission)
         comments = self.flatten_comments(submission.comments)
@@ -312,7 +312,7 @@ class SubmissionContent(Content):
 
     @classmethod
     def from_url(cls, reddit, url, loader, indent_size=2, max_indent_level=8,
-                 order=None, max_comment_cols=70):
+                 order=None, max_comment_cols=80):
 
         url = url.replace('http:', 'https:')  # Reddit forces SSL
         # Sometimes reddit will return a 403 FORBIDDEN when trying to access an

--- a/rtv/content.py
+++ b/rtv/content.py
@@ -295,7 +295,7 @@ class SubmissionContent(Content):
     """
 
     def __init__(self, submission, loader, indent_size=2, max_indent_level=8,
-                 order=None, max_comment_cols=80):
+                 order=None, max_comment_cols=120):
 
         submission_data = self.strip_praw_submission(submission)
         comments = self.flatten_comments(submission.comments)
@@ -312,7 +312,7 @@ class SubmissionContent(Content):
 
     @classmethod
     def from_url(cls, reddit, url, loader, indent_size=2, max_indent_level=8,
-                 order=None, max_comment_cols=80):
+                 order=None, max_comment_cols=120):
 
         url = url.replace('http:', 'https:')  # Reddit forces SSL
         # Sometimes reddit will return a 403 FORBIDDEN when trying to access an

--- a/rtv/content.py
+++ b/rtv/content.py
@@ -295,7 +295,7 @@ class SubmissionContent(Content):
     """
 
     def __init__(self, submission, loader, indent_size=2, max_indent_level=8,
-                 order=None):
+                 order=None, max_comment_cols=70):
 
         submission_data = self.strip_praw_submission(submission)
         comments = self.flatten_comments(submission.comments)
@@ -308,17 +308,19 @@ class SubmissionContent(Content):
         self._submission = submission
         self._submission_data = submission_data
         self._comment_data = [self.strip_praw_comment(c) for c in comments]
+        self._max_comment_cols = max_comment_cols
 
     @classmethod
     def from_url(cls, reddit, url, loader, indent_size=2, max_indent_level=8,
-                 order=None):
+                 order=None, max_comment_cols=70):
 
         url = url.replace('http:', 'https:')  # Reddit forces SSL
         # Sometimes reddit will return a 403 FORBIDDEN when trying to access an
         # np link while using OAUTH. Cause is unknown.
         url = url.replace('https://np.', 'https://www.')
         submission = reddit.get_submission(url, comment_sort=order)
-        return cls(submission, loader, indent_size, max_indent_level, order)
+        return cls(submission, loader, indent_size, max_indent_level, order,
+            max_comment_cols)
 
     @property
     def range(self):
@@ -346,7 +348,7 @@ class SubmissionContent(Content):
             data['offset'] = indent_level * self.indent_size
 
             if data['type'] == 'Comment':
-                width = n_cols - data['offset']
+                width = min(n_cols - data['offset'], self._max_comment_cols)
                 data['split_body'] = self.wrap_text(data['body'], width=width)
                 data['n_rows'] = len(data['split_body']) + 1
             else:

--- a/rtv/submission_page.py
+++ b/rtv/submission_page.py
@@ -63,7 +63,7 @@ class SubmissionPage(Page):
         self.active = False
 
     @SubmissionController.register(Command('REFRESH'))
-    def refresh_content(self, order=None, name=None, max_comment_cols=120):
+    def refresh_content(self, order=None, name=None):
         "Re-download comments and reset the page index"
 
         order = order or self.content.order
@@ -72,7 +72,7 @@ class SubmissionPage(Page):
         with self.term.loader('Refreshing page'):
             self.content = SubmissionContent.from_url(
                 self.reddit, url, self.term.loader, order=order,
-                max_comment_cols=max_comment_cols)
+                max_comment_cols=self.config['max_comment_cols'])
         if not self.term.loader.exception:
             self.nav = Navigator(self.content.get, page_index=-1)
 
@@ -155,8 +155,7 @@ class SubmissionPage(Page):
                 time.sleep(2.0)
 
             if self.term.loader.exception is None:
-                self.refresh_content(
-                    max_comment_cols=config['max_comment_cols'])
+                self.refresh_content()
             else:
                 raise TemporaryFileError()
 

--- a/rtv/submission_page.py
+++ b/rtv/submission_page.py
@@ -71,7 +71,8 @@ class SubmissionPage(Page):
 
         with self.term.loader('Refreshing page'):
             self.content = SubmissionContent.from_url(
-                self.reddit, url, self.term.loader, order=order)
+                self.reddit, url, self.term.loader, order=order,
+                max_comment_cols=config['max_comment_cols'])
         if not self.term.loader.exception:
             self.nav = Navigator(self.content.get, page_index=-1)
 

--- a/rtv/submission_page.py
+++ b/rtv/submission_page.py
@@ -23,10 +23,13 @@ class SubmissionPage(Page):
         super(SubmissionPage, self).__init__(reddit, term, config, oauth)
 
         self.controller = SubmissionController(self, keymap=config.keymap)
+
         if url:
-            self.content = SubmissionContent.from_url(reddit, url, term.loader)
+            self.content = SubmissionContent.from_url(reddit, url, term.loader,
+                max_comment_cols=config['max_comment_cols'])
         else:
-            self.content = SubmissionContent(submission, term.loader)
+            self.content = SubmissionContent(submission, term.loader,
+                max_comment_cols=config['max_comment_cols'])
         # Start at the submission post, which is indexed as -1
         self.nav = Navigator(self.content.get, page_index=-1)
         self.selected_subreddit = None

--- a/rtv/submission_page.py
+++ b/rtv/submission_page.py
@@ -25,10 +25,12 @@ class SubmissionPage(Page):
         self.controller = SubmissionController(self, keymap=config.keymap)
 
         if url:
-            self.content = SubmissionContent.from_url(reddit, url, term.loader,
+            self.content = SubmissionContent.from_url(
+                reddit, url, term.loader,
                 max_comment_cols=config['max_comment_cols'])
         else:
-            self.content = SubmissionContent(submission, term.loader,
+            self.content = SubmissionContent(
+                submission, term.loader,
                 max_comment_cols=config['max_comment_cols'])
         # Start at the submission post, which is indexed as -1
         self.nav = Navigator(self.content.get, page_index=-1)

--- a/rtv/submission_page.py
+++ b/rtv/submission_page.py
@@ -63,7 +63,7 @@ class SubmissionPage(Page):
         self.active = False
 
     @SubmissionController.register(Command('REFRESH'))
-    def refresh_content(self, order=None, name=None):
+    def refresh_content(self, order=None, name=None, max_comment_cols=120):
         "Re-download comments and reset the page index"
 
         order = order or self.content.order
@@ -72,7 +72,7 @@ class SubmissionPage(Page):
         with self.term.loader('Refreshing page'):
             self.content = SubmissionContent.from_url(
                 self.reddit, url, self.term.loader, order=order,
-                max_comment_cols=config['max_comment_cols'])
+                max_comment_cols=max_comment_cols)
         if not self.term.loader.exception:
             self.nav = Navigator(self.content.get, page_index=-1)
 
@@ -155,7 +155,8 @@ class SubmissionPage(Page):
                 time.sleep(2.0)
 
             if self.term.loader.exception is None:
-                self.refresh_content()
+                self.refresh_content(
+                    max_comment_cols=config['max_comment_cols'])
             else:
                 raise TemporaryFileError()
 

--- a/rtv/subreddit_page.py
+++ b/rtv/subreddit_page.py
@@ -140,7 +140,7 @@ class SubredditPage(Page):
 
         # Check that the subreddit can be submitted to
         name = self.content.name
-        if '+' in name or name in ('/r/all', '/r/front', '/r/me','/u/saved'):
+        if '+' in name or name in ('/r/all', '/r/front', '/r/me', '/u/saved'):
             self.term.show_notification("Can't post to {0}".format(name))
             return
 

--- a/rtv/templates/rtv.cfg
+++ b/rtv/templates/rtv.cfg
@@ -57,6 +57,9 @@ oauth_redirect_port = 65000
 ; Access permissions that will be requested.
 oauth_scope = edit,history,identity,mysubreddits,privatemessages,read,report,save,submit,subscribe,vote
 
+; Maximum number of columns for a comment
+max_comment_cols = 20
+
 [bindings]
 ##############
 # Key Bindings

--- a/rtv/templates/rtv.cfg
+++ b/rtv/templates/rtv.cfg
@@ -37,6 +37,9 @@ history_size = 200
 ; Open external links using programs defined in the mailcap config.
 enable_media = False
 
+; Maximum number of columns for a comment
+max_comment_cols = 120
+
 ################
 # OAuth Settings
 ################
@@ -56,9 +59,6 @@ oauth_redirect_port = 65000
 
 ; Access permissions that will be requested.
 oauth_scope = edit,history,identity,mysubreddits,privatemessages,read,report,save,submit,subscribe,vote
-
-; Maximum number of columns for a comment
-max_comment_cols = 80
 
 [bindings]
 ##############

--- a/rtv/templates/rtv.cfg
+++ b/rtv/templates/rtv.cfg
@@ -58,7 +58,7 @@ oauth_redirect_port = 65000
 oauth_scope = edit,history,identity,mysubreddits,privatemessages,read,report,save,submit,subscribe,vote
 
 ; Maximum number of columns for a comment
-max_comment_cols = 20
+max_comment_cols = 80
 
 [bindings]
 ##############


### PR DESCRIPTION
I opened a feature request issue for this but decided to implement it.

I've added a command line and config file argument for to set the maximum column width for submission comments. By default this is set to 80.

This makes reading comments much smoother when using a full screen terminal.

It's only my second contribution to someone else's code, so feedback on code quality is welcome :)