### PR TITLE
Option to hide the username if logged in

### DIFF
--- a/rtv/config.py
+++ b/rtv/config.py
@@ -241,7 +241,8 @@ class Config(object):
             'history_size': partial(config.getint, 'rtv'),
             'oauth_redirect_port': partial(config.getint, 'rtv'),
             'oauth_scope': lambda x: rtv[x].split(','),
-            'max_comment_cols': partial(config.getint, 'rtv')
+            'max_comment_cols': partial(config.getint, 'rtv'),
+            'hide_username': partial(config.getboolean, 'rtv')
         }
 
         for key, func in params.items():

--- a/rtv/page.py
+++ b/rtv/page.py
@@ -349,7 +349,10 @@ class Page(object):
             # to ascii or not
             width = len if self.config['ascii'] else textual_width
 
-            username = self.reddit.user.name
+            if self.config['hide_username']:
+                username = "Logged in"
+            else:
+                username = self.reddit.user.name
             s_col = (n_cols - width(username) - 1)
             # Only print username if it fits in the empty space on the right
             if (s_col - 1) >= width(sub_name):

--- a/rtv/templates/rtv.cfg
+++ b/rtv/templates/rtv.cfg
@@ -60,6 +60,9 @@ oauth_redirect_port = 65000
 ; Access permissions that will be requested.
 oauth_scope = edit,history,identity,mysubreddits,privatemessages,read,report,save,submit,subscribe,vote
 
+; Hide username if logged in, display "Logged in" instead
+hide_username = False
+
 [bindings]
 ##############
 # Key Bindings


### PR DESCRIPTION
Close #306 if merged.

A new option in the config file to hide your username if you're logged in, and display "Logged in" instead.

Local tests are passing.

Also updated the template config.