### PR TITLE
Open a submission from `/` prompt

### DIFF
--- a/rtv/docs.py
+++ b/rtv/docs.py
@@ -145,13 +145,3 @@ OAUTH_SUCCESS = """\
        <p><span style="font-weight: bold">Reddit Terminal Viewer</span>
        will now log in, you can close this window.</p>
 """
-
-TIME_ORDER_MENU = """
-Links from:
-  [1] Past hour
-  [2] Past 24 hours
-  [3] Past week
-  [4] Past month
-  [5] Past year
-  [6] All time
-"""

--- a/rtv/page.py
+++ b/rtv/page.py
@@ -93,26 +93,7 @@ class Page(object):
 
     @PageController.register(Command('SORT_TOP'))
     def sort_content_top(self):
-        if (self.content.order and 'top' not in self.content.order) or 'front' in self.content.name:
-            self.refresh_content(order='top')
-            return
-        else:
-            ch = self.term.show_notification(
-                docs.TIME_ORDER_MENU.strip('\n').splitlines())
-        if ch not in range(ord('1'), ord('6') + 1):
-            self.term.show_notification('Invalid option')
-            return
-        ord_choices = {
-            ord('1'): 'top-hour',
-            ord('2'): 'top-day',
-            ord('3'): 'top-week',
-            ord('4'): 'top-month',
-            ord('5'): 'top-year',
-            ord('6'): 'top-all',
-        }
-        order = ord_choices[ch]
-
-        self.refresh_content(order=order)
+        self.refresh_content(order='top')
 
     @PageController.register(Command('SORT_RISING'))
     def sort_content_rising(self):
@@ -125,8 +106,6 @@ class Page(object):
     @PageController.register(Command('SORT_CONTROVERSIAL'))
     def sort_content_controversial(self):
         self.refresh_content(order='controversial')
-
-    ##TODO: ADD CONTROVERSIAL SUBSORTS
 
     @PageController.register(Command('MOVE_UP'))
     def move_cursor_up(self):

--- a/rtv/page.py
+++ b/rtv/page.py
@@ -124,27 +124,9 @@ class Page(object):
 
     @PageController.register(Command('SORT_CONTROVERSIAL'))
     def sort_content_controversial(self):
-        if (self.content.order and 'controversial' not in self.content.order) or 'front' in self.content.name:
-            self.refresh_content(order='controversial')
-            return
-        else:
-            ch = self.term.show_notification(
-                docs.TIME_ORDER_MENU.strip('\n').splitlines())
-        if ch not in range(ord('1'), ord('6') + 1):
-            self.term.show_notification('Invalid option')
-            return
-        ord_choices = {
-            ord('1'): 'controversial-hour',
-            ord('2'): 'controversial-day',
-            ord('3'): 'controversial-week',
-            ord('4'): 'controversial-month',
-            ord('5'): 'controversial-year',
-            ord('6'): 'controversial-all',
-        }
-        order = ord_choices[ch]
+        self.refresh_content(order='controversial')
 
-        self.refresh_content(order=order)
-
+    ##TODO: ADD CONTROVERSIAL SUBSORTS
 
     @PageController.register(Command('MOVE_UP'))
     def move_cursor_up(self):

--- a/rtv/subreddit_page.py
+++ b/rtv/subreddit_page.py
@@ -74,10 +74,10 @@ class SubredditPage(Page):
 
         name = self.term.prompt_input('Enter page: /')
         if name is not None:
-			if not '/comments/' in name:
-				self.refresh_content(order='ignore', name=name)
-			else:
-				self.open_submission(url='https://www.reddit.com/r/'+name)
+            if not '/comments/' in name:
+                self.refresh_content(order='ignore', name=name)
+            else:
+                self.open_submission(url='https://www.reddit.com/r/'+name)
 
     @SubredditController.register(Command('SUBREDDIT_FRONTPAGE'))
     def show_frontpage(self):

--- a/rtv/subreddit_page.py
+++ b/rtv/subreddit_page.py
@@ -74,7 +74,10 @@ class SubredditPage(Page):
 
         name = self.term.prompt_input('Enter page: /')
         if name is not None:
-            self.refresh_content(order='ignore', name=name)
+			if not '/comments/' in name:
+				self.refresh_content(order='ignore', name=name)
+			else:
+				self.open_submission(url='https://www.reddit.com/r/'+name)
 
     @SubredditController.register(Command('SUBREDDIT_FRONTPAGE'))
     def show_frontpage(self):


### PR DESCRIPTION
Added the ability to open the comments page of a submission from the `/` prompt, given a correct URL. 

Changed behavior:
-  none, all valid input from previous versions should still be valid

Added behavior:
-  if a valid '/comments/' submission URL is given in the `/` prompt, the proper submission page will open

Possible improvements:
- `redd.it` URL parsing

PS: not sure what's up with line 278 (previously 275), a return symbol got automatically removed by my editor (vim-gnome)
