### PR TITLE
Use imgur api to retrieve direct links to images.

### DIFF
--- a/rtv/mime_parsers.py
+++ b/rtv/mime_parsers.py
@@ -133,10 +133,12 @@ class ImgurMIMEParser(BaseMIMEParser):
         data = json.loads(r.text)['data']
         if 'images' in data:
             # TODO: handle imgur albums with mixed content, i.e. jpeg and gifv
-            urls = ' '.join([d['link'] for d in data['images'] if not d['animated']])
-            return urls, 'image/x-imgur-album'
+            links = ' '.join([d['link'] for d in data['images'] if not d['animated']])
+            return links.replace('http://', 'https://'), 'image/x-imgur-album'
         else :
-            return (data['mp4'], 'video/mp4') if data['animated'] else (data['link'], data['type'])
+            link = data['mp4'] if data['animated'] else data['link']
+            mime = 'video/mp4' if data['animated'] else data['type']
+            return link.replace('http://', 'https://'), mime
 
 
 class InstagramMIMEParser(BaseMIMEParser):

--- a/rtv/mime_parsers.py
+++ b/rtv/mime_parsers.py
@@ -4,7 +4,6 @@ import mimetypes
 
 import requests
 from bs4 import BeautifulSoup
-import json
 
 _logger = logging.getLogger(__name__)
 
@@ -130,7 +129,7 @@ class ImgurMIMEParser(BaseMIMEParser):
             if r.status_code != 200:
                 return url, None
 
-        data = json.loads(r.text)['data']
+        data = r.json()['data']
         if 'images' in data:
             # TODO: handle imgur albums with mixed content, i.e. jpeg and gifv
             links = ' '.join([d['link'] for d in data['images'] if not d['animated']])

--- a/rtv/mime_parsers.py
+++ b/rtv/mime_parsers.py
@@ -124,19 +124,19 @@ class ImgurMIMEParser(BaseMIMEParser):
 
         r = requests.get(endpoint.format(domain=domain, page_hash=page_hash),
                                          headers=header)
-        if r.status_code == 404:
+        if r.status_code != 200:
             r = requests.get(endpoint.format(domain='image',
                                 page_hash=page_hash), headers=header)
+            if r.status_code != 200:
+                return url, None
 
         data = json.loads(r.text)['data']
         if 'images' in data:
             # TODO: handle imgur albums with mixed content, i.e. jpeg and gifv
             urls = ' '.join([d['link'] for d in data['images'] if not d['animated']])
             return urls, 'image/x-imgur-album'
-        else:
+        else :
             return (data['mp4'], 'video/mp4') if data['animated'] else (data['link'], data['type'])
-
-        return url, None
 
 
 class InstagramMIMEParser(BaseMIMEParser):

--- a/tests/test_mime_parsers.py
+++ b/tests/test_mime_parsers.py
@@ -41,12 +41,12 @@ URLS = OrderedDict([
         'https://i.imgur.com/yW0kbMi.jpg',
         'image/jpeg')),
     ('imgur_2', (
-        'http://imgur.com/yjP1v4B',
-        'https://i.imgur.com/yjP1v4Bh.jpg',
-        'image/jpeg')),
+        'http://imgur.com/gallery/yjP1v4B',
+        'https://i.imgur.com/yjP1v4B.mp4',
+        'video/mp4')),
     ('imgur_album', (
         'http://imgur.com/a/qx9t5',
-        'http://i.imgur.com/uEt0YLI.jpg',
+        'https://i.imgur.com/uEt0YLI.jpg',
         'image/x-imgur-album')),
     ('instagram_image', (
         'https://www.instagram.com/p/BIxQ0vrBN2Y/?taken-by=kimchi_chic',


### PR DESCRIPTION
Entire imgur albums can be downloaded rather than the max 10 images from scraping the webpage.
There is a rate limit on the number of request. I'm not sure if there are enough users of `rtv` to run into any trouble.