### PR TITLE
Issue #343 Added method to clear screen

### DIFF
--- a/rtv/page.py
+++ b/rtv/page.py
@@ -397,7 +397,10 @@ class Page(object):
         # tmux) but many people override ther $TERM in their tmux.conf or
         # .bashrc file. Using clearok() instead seems to fix the problem, at
         # the expense of slightly more expensive screen refreshes.
-        self.term.stdscr.clearok(True)
+        # However clearok() introduced a screen flash bug to urxvt users so the 
+        # clear_screen() method chooses which of the two stdscr methods to use
+        # based on the $TERM environment variable
+        self.term.clear_screen()
         self.term.stdscr.refresh()
 
     def _draw_header(self):

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -59,6 +59,7 @@ class Terminal(object):
         self.loader = LoadScreen(self)
         self._display = None
         self._mailcap_dict = mailcap.getcaps()
+        self._term = os.environ['TERM']
 
     @property
     def up_arrow(self):
@@ -772,7 +773,7 @@ class Terminal(object):
     
     # Resolves tmux touchwin() bug and urxvt clearok() flashing bug
     def clear_screen(self):
-        if os.environ['TERM'] is not 'xterm-256color':
+        if self._term != 'xterm-256color':
             self.stdscr.touchwin()
         else:
             self.stdscr.clearok(True)

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -769,3 +769,11 @@ class Terminal(object):
 
         out = '\n'.join(stack)
         return out
+    
+    # Resolves tmux touchwin() bug and urxvt clearok() flashing bug
+    def clear_screen(self):
+        if os.environ['TERM'] is not 'xterm-256color':
+            self.stdscr.touchwin()
+        else:
+            self.stdscr.clearok(True)
+    


### PR DESCRIPTION
School is over so I finally got around to this. The clear_screen() method in the Terminal class checks the $TERM variable in an attempt to avoid both the tmux and urxvt bugs. I was unable to test with tmux but it removes the flashing using urxvt.