### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 python:
   - 2.7
   - 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-dist: precise
 python:
   - 2.7
   - 3.3

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -37,7 +37,8 @@ def test_terminal_properties(terminal, config):
 
     terminal._display = None
     with mock.patch('rtv.terminal.sys') as sys, \
-            mock.patch.dict('os.environ', {'DISPLAY': ''}):
+            mock.patch('os.environ', {'DISPLAY': ''}), \
+            mock.patch('webbrowser._tryorder', new=[]):
         sys.platform = 'darwin'
         assert terminal.display is True
 


### PR DESCRIPTION
On Ubuntu 14.04, ``webbrowser._tryorder`` was returning ``["www.browser", "w3m"]``. This was causing a failure in a test that was trying to spoof the darwin platform. The solution was to mock out  ``_tryorder`` in order to have better control over the environment.