### PR TITLE
RE #415: Add '[S]' to submitter username on comments

### DIFF
--- a/rtv/submission_page.py
+++ b/rtv/submission_page.py
@@ -262,7 +262,10 @@ class SubmissionPage(Page):
 
             attr = curses.A_BOLD
             attr |= (Color.BLUE if not data['is_author'] else Color.GREEN)
-            self.term.add_line(win, '{author} '.format(**data), row, 1, attr)
+            text = '{author} '.format(**data)
+            if data['is_author']:
+                text += '[S] '
+            self.term.add_line(win, text, row, 1, attr)
 
             if data['flair']:
                 attr = curses.A_BOLD | Color.YELLOW


### PR DESCRIPTION
Per #415, add '[S]' to the end of the submitter's username on their own comments.