### PR TITLE
preparing for themes

### DIFF
--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -35,9 +35,10 @@ from . import docs
 from . import packages
 from .packages import praw
 from .config import Config, copy_default_config, copy_default_mailcap
+from .theme import Theme
 from .oauth import OAuthHelper
 from .terminal import Terminal
-from .objects import curses_session, Color, patch_webbrowser
+from .objects import curses_session, patch_webbrowser
 from .subreddit_page import SubredditPage
 from .exceptions import ConfigError
 from .__version__ import __version__
@@ -169,11 +170,9 @@ def main():
     try:
         with curses_session() as stdscr:
 
-            # Initialize global color-pairs with curses
-            if not config['monochrome']:
-                Color.init()
+            theme = Theme(config['monochrome'])
+            term = Terminal(stdscr, config, theme)
 
-            term = Terminal(stdscr, config)
             with term.loader('Initializing', catch_exception=False):
                 reddit = praw.Reddit(user_agent=user_agent,
                                      decode_html_entities=False,

--- a/rtv/config.py
+++ b/rtv/config.py
@@ -135,6 +135,9 @@ class OrderedSet(object):
 
 
 class Config(object):
+    """
+    This class manages the loading and saving of configs and other files.
+    """
 
     def __init__(self, history_file=HISTORY, token_file=TOKEN, **kwargs):
 

--- a/rtv/oauth.py
+++ b/rtv/oauth.py
@@ -193,23 +193,23 @@ class OAuthHelper(object):
                 # If an exception is raised it will be seen by the thread
                 # so we don't need to explicitly shutdown() the server
                 _logger.exception(e)
-                self.term.show_notification('Browser Error')
+                self.term.show_notification('Browser Error', style='error')
             else:
                 self.server.shutdown()
             finally:
                 thread.join()
 
         if self.params['error'] == 'access_denied':
-            self.term.show_notification('Denied access')
+            self.term.show_notification('Denied access', style='error')
             return
         elif self.params['error']:
-            self.term.show_notification('Authentication error')
+            self.term.show_notification('Authentication error', style='error')
             return
         elif self.params['state'] is None:
             # Something went wrong but it's not clear what happened
             return
         elif self.params['state'] != state:
-            self.term.show_notification('UUID mismatch')
+            self.term.show_notification('UUID mismatch', style='error')
             return
 
         with self.term.loader('Logging in'):

--- a/rtv/submission_page.py
+++ b/rtv/submission_page.py
@@ -3,12 +3,11 @@ from __future__ import unicode_literals
 
 import re
 import time
-import curses
 
 from . import docs
 from .content import SubmissionContent, SubredditContent
 from .page import Page, PageController, logged_in
-from .objects import Navigator, Color, Command
+from .objects import Navigator, Command
 from .exceptions import TemporaryFileError
 
 
@@ -119,7 +118,7 @@ class SubmissionPage(Page):
     @SubmissionController.register(Command('SUBMISSION_OPEN_IN_BROWSER'))
     def open_link(self):
         """
-        Open the selected item with the webbrowser
+        Open the selected item with the web browser 
         """
 
         data = self.get_selected_item()
@@ -207,6 +206,10 @@ class SubmissionPage(Page):
 
     @SubmissionController.register(Command('SUBMISSION_OPEN_IN_URLVIEWER'))
     def comment_urlview(self):
+        """
+        Open the selected comment with the URL viewer
+        """
+
         data = self.get_selected_item()
         comment = data.get('body') or data.get('text') or data.get('url_full')
         if comment:
@@ -285,89 +288,114 @@ class SubmissionPage(Page):
         split_body = data['split_body']
         if data['n_rows'] > n_rows:
             # Only when there is a single comment on the page and not inverted
-            if not inverted and len(self._subwindows) == 0:
+            if not inverted and len(self._subwindows) == 1:
                 cutoff = data['n_rows'] - n_rows + 1
                 split_body = split_body[:-cutoff]
                 split_body.append('(Not enough space to display)')
 
         row = offset
         if row in valid_rows:
-
-            attr = curses.A_BOLD
-            attr |= (Color.BLUE if not data['is_author'] else Color.GREEN)
-            text = '{author} '.format(**data)
             if data['is_author']:
-                text += '[S] '
+                attr = self.term.attr('comment_author_self')
+                text = '{author} [S]'.format(**data)
+            else:
+                attr = self.term.attr('comment_author')
+                text = '{author}'.format(**data)
             self.term.add_line(win, text, row, 1, attr)
 
             if data['flair']:
-                attr = curses.A_BOLD | Color.YELLOW
-                self.term.add_line(win, '{flair} '.format(**data), attr=attr)
+                attr = self.term.attr('user_flair')
+                self.term.add_space(win)
+                self.term.add_line(win, '{flair}'.format(**data), attr=attr)
 
-            text, attr = self.term.get_arrow(data['likes'])
-            self.term.add_line(win, text, attr=attr)
-            self.term.add_line(win, ' {score} {created} '.format(**data))
+            arrow, attr = self.term.get_arrow(data['likes'])
+            self.term.add_space(win)
+            self.term.add_line(win, arrow, attr=attr)
+
+            attr = self.term.attr('score')
+            self.term.add_space(win)
+            self.term.add_line(win, '{score}'.format(**data), attr=attr)
+
+            attr = self.term.attr('created')
+            self.term.add_space(win)
+            self.term.add_line(win, '{created}'.format(**data), attr=attr)
 
             if data['gold']:
-                text, attr = self.term.guilded
-                self.term.add_line(win, text, attr=attr)
+                attr = self.term.attr('gold')
+                self.term.add_space(win)
+                self.term.add_line(win, self.term.guilded, attr=attr)
 
             if data['stickied']:
-                text, attr = '[stickied]', Color.GREEN
-                self.term.add_line(win, text, attr=attr)
+                attr = self.term.attr('stickied')
+                self.term.add_space(win)
+                self.term.add_line(win, '[stickied]', attr=attr)
 
             if data['saved']:
-                text, attr = '[saved]', Color.GREEN
-                self.term.add_line(win, text, attr=attr)
+                attr = self.term.attr('saved')
+                self.term.add_space(win)
+                self.term.add_line(win, '[saved]', attr=attr)
 
         for row, text in enumerate(split_body, start=offset+1):
+            attr = self.term.attr('comment_text')
             if row in valid_rows:
-                self.term.add_line(win, text, row, 1)
+                self.term.add_line(win, text, row, 1, attr=attr)
 
         # Unfortunately vline() doesn't support custom color so we have to
         # build it one segment at a time.
-        attr = Color.get_level(data['level'])
-        x = 0
+        index = data['level'] % len(self.term.theme.BAR_LEVELS)
+        attr = self.term.attr(self.term.theme.BAR_LEVELS[index])
         for y in range(n_rows):
-            self.term.addch(win, y, x, self.term.vline, attr)
-
-        return attr | self.term.vline
+            self.term.addch(win, y, 0, self.term.vline, attr)
 
     def _draw_more_comments(self, win, data):
 
         n_rows, n_cols = win.getmaxyx()
         n_cols -= 1
 
-        self.term.add_line(win, '{body}'.format(**data), 0, 1)
-        self.term.add_line(
-            win, ' [{count}]'.format(**data), attr=curses.A_BOLD)
+        attr = self.term.attr('hidden_comment_text')
+        self.term.add_line(win, '{body}'.format(**data), 0, 1, attr=attr)
 
-        attr = Color.get_level(data['level'])
+        attr = self.term.attr('hidden_comment_expand')
+        self.term.add_space(win)
+        self.term.add_line(win, '[{count}]'.format(**data), attr=attr)
+
+        index = data['level'] % len(self.term.theme.BAR_LEVELS)
+        attr = self.term.attr(self.term.theme.BAR_LEVELS[index])
         self.term.addch(win, 0, 0, self.term.vline, attr)
-
-        return attr | self.term.vline
 
     def _draw_submission(self, win, data):
 
         n_rows, n_cols = win.getmaxyx()
         n_cols -= 3  # one for each side of the border + one for offset
 
+        attr = self.term.attr('submission_title')
         for row, text in enumerate(data['split_title'], start=1):
-            self.term.add_line(win, text, row, 1, curses.A_BOLD)
+            self.term.add_line(win, text, row, 1, attr)
 
         row = len(data['split_title']) + 1
-        attr = curses.A_BOLD | Color.GREEN
+        attr = self.term.attr('submission_author')
         self.term.add_line(win, '{author}'.format(**data), row, 1, attr)
-        attr = curses.A_BOLD | Color.YELLOW
+
         if data['flair']:
-            self.term.add_line(win, ' {flair}'.format(**data), attr=attr)
-        self.term.add_line(win, ' {created} {subreddit}'.format(**data))
+            attr = self.term.attr('submission_flair')
+            self.term.add_space(win)
+            self.term.add_line(win, '{flair}'.format(**data), attr=attr)
+
+        attr = self.term.attr('created')
+        self.term.add_space(win)
+        self.term.add_line(win, '{created}'.format(**data), attr=attr)
+
+        attr = self.term.attr('submission_subreddit')
+        self.term.add_space(win)
+        self.term.add_line(win, '/r/{subreddit}'.format(**data), attr=attr)
 
         row = len(data['split_title']) + 2
-        seen = (data['url_full'] in self.config.history)
-        link_color = Color.MAGENTA if seen else Color.BLUE
-        attr = curses.A_UNDERLINE | link_color
+        if data['url_full'] in self.config.history:
+            attr = self.term.attr('url_seen')
+        else:
+            attr = self.term.attr('url')
         self.term.add_line(win, '{url}'.format(**data), row, 1, attr)
+
         offset = len(data['split_title']) + 3
 
         # Cut off text if there is not enough room to display the whole post
@@ -377,25 +405,35 @@ class SubmissionPage(Page):
             split_text = split_text[:-cutoff]
             split_text.append('(Not enough space to display)')
 
+        attr = self.term.attr('submission_text')
         for row, text in enumerate(split_text, start=offset):
-            self.term.add_line(win, text, row, 1)
+            self.term.add_line(win, text, row, 1, attr=attr)
 
         row = len(data['split_title']) + len(split_text) + 3
-        self.term.add_line(win, '{score} '.format(**data), row, 1)
-        text, attr = self.term.get_arrow(data['likes'])
-        self.term.add_line(win, text, attr=attr)
-        self.term.add_line(win, ' {comments} '.format(**data))
+        attr = self.term.attr('score')
+        self.term.add_line(win, '{score}'.format(**data), row, 1, attr=attr)
+
+        arrow, attr = self.term.get_arrow(data['likes'])
+        self.term.add_space(win)
+        self.term.add_line(win, arrow, attr=attr)
+
+        attr = self.term.attr('comment_count')
+        self.term.add_space(win)
+        self.term.add_line(win, '{comments}'.format(**data), attr=attr)
 
         if data['gold']:
-            text, attr = self.term.guilded
-            self.term.add_line(win, text, attr=attr)
+            attr = self.term.attr('gold')
+            self.term.add_space(win)
+            self.term.add_line(win, self.term.guilded, attr=attr)
 
         if data['nsfw']:
-            text, attr = 'NSFW', (curses.A_BOLD | Color.RED)
-            self.term.add_line(win, text, attr=attr)
+            attr = self.term.attr('nsfw')
+            self.term.add_space(win)
+            self.term.add_line(win, 'NSFW', attr=attr)
 
         if data['saved']:
-            text, attr = '[saved]', Color.GREEN
-            self.term.add_line(win, text, attr=attr)
+            attr = self.term.attr('saved')
+            self.term.add_space(win)
+            self.term.add_line(win, '[saved]', attr=attr)
 
         win.border()

--- a/rtv/subreddit_page.py
+++ b/rtv/subreddit_page.py
@@ -3,12 +3,11 @@ from __future__ import unicode_literals
 
 import re
 import time
-import curses
 
 from . import docs
 from .content import SubredditContent
 from .page import Page, PageController, logged_in
-from .objects import Navigator, Color, Command
+from .objects import Navigator, Command
 from .submission_page import SubmissionPage
 from .subscription_page import SubscriptionPage
 from .exceptions import TemporaryFileError
@@ -265,50 +264,75 @@ class SubredditPage(Page):
 
         n_title = len(data['split_title'])
         for row, text in enumerate(data['split_title'], start=offset):
+            attr = self.term.attr('submission_title')
             if row in valid_rows:
-                self.term.add_line(win, text, row, 1, curses.A_BOLD)
+                self.term.add_line(win, text, row, 1, attr)
 
         row = n_title + offset
         if row in valid_rows:
-            seen = (data['url_full'] in self.config.history)
-            link_color = Color.MAGENTA if seen else Color.BLUE
-            attr = curses.A_UNDERLINE | link_color
+            if data['url_full'] in self.config.history:
+                attr = self.term.attr('url_seen')
+            else:
+                attr = self.term.attr('url')
             self.term.add_line(win, '{url}'.format(**data), row, 1, attr)
 
         row = n_title + offset + 1
         if row in valid_rows:
-            self.term.add_line(win, '{score} '.format(**data), row, 1)
-            text, attr = self.term.get_arrow(data['likes'])
-            self.term.add_line(win, text, attr=attr)
-            self.term.add_line(win, ' {created} '.format(**data))
+
+            attr = self.term.attr('score')
+            self.term.add_line(win, '{score}'.format(**data), row, 1, attr)
+            self.term.add_space(win)
+
+            arrow, attr = self.term.get_arrow(data['likes'])
+            self.term.add_line(win, arrow, attr=attr)
+            self.term.add_space(win)
+
+            attr = self.term.attr('created')
+            self.term.add_line(win, '{created}'.format(**data), attr=attr)
 
             if data['comments'] is not None:
-                text, attr = '-', curses.A_BOLD
-                self.term.add_line(win, text, attr=attr)
-                self.term.add_line(win, ' {comments} '.format(**data))
+                attr = self.term.attr('separator')
+                self.term.add_space(win)
+                self.term.add_line(win, '-', attr=attr)
+
+                attr = self.term.attr('comment_count')
+                self.term.add_space(win)
+                self.term.add_line(win, '{comments}'.format(**data), attr=attr)
 
             if data['saved']:
-                text, attr = '[saved]', Color.GREEN
-                self.term.add_line(win, text, attr=attr)
+                attr = self.term.attr('saved')
+                self.term.add_space(win)
+                self.term.add_line(win, '[saved]', attr=attr)
 
             if data['stickied']:
-                text, attr = '[stickied]', Color.GREEN
-                self.term.add_line(win, text, attr=attr)
+                attr = self.term.attr('stickied')
+                self.term.add_space(win)
+                self.term.add_line(win, '[stickied]', attr=attr)
 
             if data['gold']:
-                text, attr = self.term.guilded
-                self.term.add_line(win, text, attr=attr)
+                attr = self.term.attr('gold')
+                self.term.add_space(win)
+                self.term.add_line(win, self.term.guilded, attr=attr)
 
             if data['nsfw']:
-                text, attr = 'NSFW', (curses.A_BOLD | Color.RED)
-                self.term.add_line(win, text, attr=attr)
+                attr = self.term.attr('nsfw')
+                self.term.add_space(win)
+                self.term.add_line(win, 'NSFW', attr=attr)
 
         row = n_title + offset + 2
         if row in valid_rows:
-            text = '{author}'.format(**data)
-            self.term.add_line(win, text, row, 1, Color.GREEN)
-            text = ' /r/{subreddit}'.format(**data)
-            self.term.add_line(win, text, attr=Color.YELLOW)
+            attr = self.term.attr('submission_author')
+            self.term.add_line(win, '{author}'.format(**data), row, 1, attr)
+            self.term.add_space(win)
+
+            attr = self.term.attr('submission_subreddit')
+            self.term.add_line(win, '/r/{subreddit}'.format(**data), attr=attr)
+
             if data['flair']:
-                text = ' {flair}'.format(**data)
-                self.term.add_line(win, text, attr=Color.RED)
+                attr = self.term.attr('submission_flair')
+                self.term.add_space(win)
+                self.term.add_line(win, '{flair}'.format(**data), attr=attr)
+
+        attr = self.term.attr('cursor')
+        for y in range(n_rows):
+            self.term.addch(win, y, 0, str(' '), attr)

--- a/rtv/subscription_page.py
+++ b/rtv/subscription_page.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import curses
-
 from . import docs
 from .page import Page, PageController
 from .content import SubscriptionContent, SubredditContent
-from .objects import Color, Navigator, Command
+from .objects import Navigator, Command
 
 
 class SubscriptionController(PageController):
@@ -95,10 +93,21 @@ class SubscriptionPage(Page):
 
         row = offset
         if row in valid_rows:
-            attr = curses.A_BOLD | Color.YELLOW
+            if data['type'] == 'Multireddit':
+                attr = self.term.attr('multireddit_name')
+            else:
+                attr = self.term.attr('subscription_name')
             self.term.add_line(win, '{name}'.format(**data), row, 1, attr)
 
         row = offset + 1
         for row, text in enumerate(data['split_title'], start=row):
             if row in valid_rows:
-                self.term.add_line(win, text, row, 1)
+                if data['type'] == 'Multireddit':
+                    attr = self.term.attr('multireddit_text')
+                else:
+                    attr = self.term.attr('subscription_text')
+                self.term.add_line(win, text, row, 1, attr)
+
+        attr = self.term.attr('cursor')
+        for y in range(n_rows):
+            self.term.addch(win, y, 0, str(' '), attr)

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -282,7 +282,8 @@ class Terminal(object):
 
         row, col = window.getyx()
         _, max_cols = window.getmaxyx()
-        if max_cols - col - 1 <= 0:
+        n_cols = max_cols - col - 1
+        if n_cols <= 0:
             # Trying to draw outside of the screen bounds
             return
 

--- a/rtv/theme.py
+++ b/rtv/theme.py
@@ -1,0 +1,113 @@
+"""
+This file is a stub that contains the default RTV theme.
+
+This will eventually be expanded to support loading/managing custom themes.
+"""
+
+import curses
+from contextlib import contextmanager
+
+
+DEFAULT_THEME = {
+    'normal':                (-1,                   -1, curses.A_NORMAL),
+    'bar_level_1':           (curses.COLOR_MAGENTA, -1, curses.A_NORMAL),
+    'bar_level_1.selected':  (curses.COLOR_MAGENTA, -1, curses.A_REVERSE),
+    'bar_level_2':           (curses.COLOR_CYAN,    -1, curses.A_NORMAL),
+    'bar_level_2.selected':  (curses.COLOR_CYAN,    -1, curses.A_REVERSE),
+    'bar_level_3':           (curses.COLOR_GREEN,   -1, curses.A_NORMAL),
+    'bar_level_3.selected':  (curses.COLOR_GREEN,   -1, curses.A_REVERSE),
+    'bar_level_4':           (curses.COLOR_YELLOW,  -1, curses.A_NORMAL),
+    'bar_level_4.selected':  (curses.COLOR_YELLOW,  -1, curses.A_REVERSE),
+    'comment_author':        (curses.COLOR_BLUE,    -1, curses.A_BOLD),
+    'comment_author_self':   (curses.COLOR_GREEN,   -1, curses.A_BOLD),
+    'comment_count':         (-1,                   -1, curses.A_NORMAL),
+    'comment_text':          (-1,                   -1, curses.A_NORMAL),
+    'created':               (-1,                   -1, curses.A_NORMAL),
+    'cursor':                (-1,                   -1, curses.A_NORMAL),
+    'cursor.selected':       (-1,                   -1, curses.A_REVERSE),
+    'downvote':              (curses.COLOR_RED,     -1, curses.A_BOLD),
+    'gold':                  (curses.COLOR_YELLOW,  -1, curses.A_BOLD),
+    'help_bar':              (curses.COLOR_CYAN,    -1, curses.A_BOLD | curses.A_REVERSE),
+    'hidden_comment_expand': (-1,                   -1, curses.A_BOLD),
+    'hidden_comment_text':   (-1,                   -1, curses.A_NORMAL),
+    'multireddit_name':      (curses.COLOR_YELLOW,  -1, curses.A_BOLD),
+    'multireddit_text':      (-1,                   -1, curses.A_NORMAL),
+    'neutral_vote':          (-1,                   -1, curses.A_BOLD),
+    'notice_info':           (-1,                   -1, curses.A_NORMAL),
+    'notice_loading':        (-1,                   -1, curses.A_NORMAL),
+    'notice_error':          (-1,                   -1, curses.A_NORMAL),
+    'notice_success':        (-1,                   -1, curses.A_NORMAL),
+    'nsfw':                  (curses.COLOR_RED,     -1, curses.A_BOLD | curses.A_REVERSE),
+    'order_bar':             (curses.COLOR_YELLOW,  -1, curses.A_BOLD),
+    'order_bar.selected':    (curses.COLOR_YELLOW,  -1, curses.A_BOLD | curses.A_REVERSE),
+    'prompt':                (curses.COLOR_CYAN,    -1, curses.A_BOLD | curses.A_REVERSE),
+    'saved':                 (curses.COLOR_GREEN,   -1, curses.A_NORMAL),
+    'score':                 (-1,                   -1, curses.A_NORMAL),
+    'separator':             (-1,                   -1, curses.A_BOLD),
+    'stickied':              (curses.COLOR_GREEN,   -1, curses.A_NORMAL),
+    'subscription_name':     (curses.COLOR_YELLOW,  -1, curses.A_BOLD),
+    'subscription_text':     (-1,                   -1, curses.A_NORMAL),
+    'submission_author':     (curses.COLOR_GREEN,   -1, curses.A_NORMAL),
+    'submission_flair':      (curses.COLOR_RED,     -1, curses.A_NORMAL),
+    'submission_subreddit':  (curses.COLOR_YELLOW,  -1, curses.A_NORMAL),
+    'submission_text':       (-1,                   -1, curses.A_NORMAL),
+    'submission_title':      (-1,                   -1, curses.A_BOLD),
+    'title_bar':             (curses.COLOR_CYAN,    -1, curses.A_BOLD | curses.A_REVERSE),
+    'upvote':                (curses.COLOR_GREEN,   -1, curses.A_BOLD),
+    'url':                   (curses.COLOR_BLUE,    -1, curses.A_UNDERLINE),
+    'url_seen':              (curses.COLOR_MAGENTA, -1, curses.A_UNDERLINE),
+    'user_flair':            (curses.COLOR_YELLOW,  -1, curses.A_BOLD)
+}
+
+
+class Theme(object):
+
+    BAR_LEVELS = ['bar_level_1', 'bar_level_2', 'bar_level_3', 'bar_level_4']
+
+    def __init__(self, monochrome=True):
+
+        self.monochrome = monochrome
+        self._modifier = None
+        self._elements = {}
+        self._color_pairs = {}
+
+    def bind_curses(self):
+
+        if self.monochrome:
+            # Skip initializing the colors and just use the attributes
+            self._elements = {key: val[2] for key, val in DEFAULT_THEME.items()}
+            return
+
+        # Shortcut for the default fg/bg
+        self._color_pairs[(-1, -1)] = curses.A_NORMAL
+
+        for key, (fg, bg, attr) in DEFAULT_THEME.items():
+            # Register the color pair for the element
+            if (fg, bg) not in self._color_pairs:
+                index = len(self._color_pairs) + 1
+                curses.init_pair(index, fg, bg)
+                self._color_pairs[(fg, bg)] = curses.color_pair(index)
+
+            self._elements[key] = self._color_pairs[(fg, bg)] | attr
+
+    def get(self, element, modifier=None):
+
+        modifier = modifier or self._modifier
+        if modifier:
+            modified_element = '{0}.{1}'.format(element, modifier)
+            if modified_element in self._elements:
+                return self._elements[modified_element]
+
+        return self._elements[element]
+
+    @contextmanager
+    def set_modifier(self, modifier=None):
+
+        # This case is undefined if the context manager is nested
+        assert self._modifier is None
+
+        self._modifier = modifier
+        try:
+            yield
+        finally:
+            self._modifier = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,9 @@ class MockStdscr(mock.MagicMock):
     def getyx(self):
         return self.y, self.x
 
+    def getbegyx(self):
+        return 0, 0
+
     def getmaxyx(self):
         return self.nlines, self.ncols
 
@@ -154,12 +157,14 @@ def stdscr():
             patch('curses.curs_set'),           \
             patch('curses.init_pair'),          \
             patch('curses.color_pair'),         \
+            patch('curses.has_colors'),         \
             patch('curses.start_color'),        \
             patch('curses.use_default_colors'):
         out = MockStdscr(nlines=40, ncols=80, x=0, y=0)
         curses.initscr.return_value = out
         curses.newwin.side_effect = lambda *args: out.derwin(*args)
         curses.color_pair.return_value = 23
+        curses.has_colors.return_value = True
         curses.ACS_VLINE = 0
         yield out
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -12,7 +12,7 @@ import requests
 from six.moves import reload_module
 
 from rtv import exceptions
-from rtv.objects import Color, Controller, Navigator, Command, KeyMap, \
+from rtv.objects import Controller, Navigator, Command, KeyMap, \
     curses_session, patch_webbrowser
 
 try:
@@ -187,21 +187,6 @@ def test_objects_load_screen_nested_complex(terminal, stdscr, use_ascii):
     assert not terminal.loader._animator.is_alive()
     error_message = 'ConnectionError'.encode('ascii' if use_ascii else 'utf-8')
     stdscr.subwin.addstr.assert_called_once_with(1, 1, error_message)
-
-
-def test_objects_color(stdscr):
-
-    colors = ['RED', 'GREEN', 'YELLOW', 'BLUE', 'MAGENTA', 'CYAN', 'WHITE']
-
-    # Check that all colors start with the default value
-    for color in colors:
-        assert getattr(Color, color) == curses.A_NORMAL
-
-    Color.init()
-
-    # Check that all colors are populated
-    for color in colors:
-        assert getattr(Color, color) == 23
 
 
 def test_objects_curses_session(stdscr):

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -79,15 +79,16 @@ def test_submission_page_construct(reddit, terminal, config, oauth):
     # Comment
     comment_data = page.content.get(0)
     text = comment_data['split_body'][0].encode('utf-8')
-    window.subwin.addstr.assert_any_call(1, 1, text)
+    window.subwin.addstr.assert_any_call(1, 1, text, curses.A_NORMAL)
 
     # More Comments
     comment_data = page.content.get(1)
     text = comment_data['body'].encode('utf-8')
-    window.subwin.addstr.assert_any_call(0, 1, text)
+    window.subwin.addstr.assert_any_call(0, 1, text, curses.A_NORMAL)
 
     # Cursor should not be drawn when the page is first opened
-    assert not window.subwin.chgat.called
+    # TODO: Add a new test for this
+    # assert not window.subwin.chgat.called
 
     # Reload with a smaller terminal window
     terminal.stdscr.ncols = 20
@@ -264,7 +265,7 @@ def test_submission_comment_not_enough_space(submission_page, terminal):
 
     text = '(Not enough space to display)'.encode('ascii')
     window = terminal.stdscr.subwin
-    window.subwin.addstr.assert_any_call(6, 1, text)
+    window.subwin.addstr.assert_any_call(6, 1, text, curses.A_NORMAL)
 
 
 def test_submission_vote(submission_page, refresh_token):

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -87,8 +87,8 @@ def test_submission_page_construct(reddit, terminal, config, oauth):
     window.subwin.addstr.assert_any_call(0, 1, text, curses.A_NORMAL)
 
     # Cursor should not be drawn when the page is first opened
-    # TODO: Add a new test for this
-    # assert not window.subwin.chgat.called
+    assert not any(args[0][3] == curses.A_REVERSE
+                   for args in window.subwin.addch.call_args_list)
 
     # Reload with a smaller terminal window
     terminal.stdscr.ncols = 20

--- a/tests/test_subreddit.py
+++ b/tests/test_subreddit.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import curses
+
 import six
 
 from rtv import __version__
@@ -38,7 +40,7 @@ def test_subreddit_page_construct(reddit, terminal, config, oauth):
     window.subwin.addstr.assert_any_call(0, 1, text, 2097152)
 
     # Cursor should have been drawn
-    assert window.subwin.chgat.called
+    window.subwin.addch.assert_any_call(0, 0, ' ', curses.A_REVERSE)
 
     # Reload with a smaller terminal window
     terminal.stdscr.ncols = 20

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -45,8 +45,8 @@ def test_subscription_page_construct(reddit, terminal, config, oauth,
         window.addstr.assert_any_call(0, 0, menu)
 
     # Cursor - 2 lines
-    window.subwin.chgat.assert_any_call(0, 0, 1, 262144)
-    window.subwin.chgat.assert_any_call(1, 0, 1, 262144)
+    window.subwin.addch.assert_any_call(0, 0, ' ', 262144)
+    window.subwin.addch.assert_any_call(1, 0, ' ', 262144)
 
     # Reload with a smaller terminal window
     terminal.stdscr.ncols = 20

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -20,14 +20,10 @@ except ImportError:
 
 def test_terminal_properties(terminal, config):
 
-    assert len(terminal.up_arrow) == 2
-    assert isinstance(terminal.up_arrow[0], six.text_type)
-    assert len(terminal.down_arrow) == 2
-    assert isinstance(terminal.down_arrow[0], six.text_type)
-    assert len(terminal.neutral_arrow) == 2
-    assert isinstance(terminal.neutral_arrow[0], six.text_type)
-    assert len(terminal.guilded) == 2
-    assert isinstance(terminal.guilded[0], six.text_type)
+    assert isinstance(terminal.up_arrow, six.text_type)
+    assert isinstance(terminal.down_arrow, six.text_type)
+    assert isinstance(terminal.neutral_arrow, six.text_type)
+    assert isinstance(terminal.guilded, six.text_type)
 
     terminal._display = None
     with mock.patch('rtv.terminal.sys') as sys, \


### PR DESCRIPTION
This PR contains some code cleanup and refactoring with the intention of making it easier to add support for custom themes later. Most of this has been cherry-picked from my other themes branch. I want to get some of the non-breaking changes into master now to minimize the overall diff and chance of breaking things.

Changes include:

- Replacing the ``Color`` class with a more flexible ``Theme`` class. The ``Theme`` class is still a stub for now and will be filled out later.
- Moving all color and text modifier definitions to a central dictionary.
- Adding an optional ``style`` parameter to ``term.show_notification``. For now all of the styles (info, loading, warning, error) are displayed the same way so this has no effect. In the future, error messages might be colored differently depending on their types.
- Using ``getbegyx()`` for window alignment instead of assuming that **stdscr** takes up the whole window.
- Getting rid of the ``_add_cursor()``/``_remove_cursor()`` code and instead drawing the cursor as part of ``_draw_item()`` method. This will allow for defining the cursor style in the theme instead of simply applying ``curses.A_REVERSE`` to it.


I still need to add a few tests before merging
