### PR TITLE
Youtube videos are now directly handled by mpv in mailcap

### DIFF
--- a/rtv/templates/mailcap
+++ b/rtv/templates/mailcap
@@ -31,7 +31,7 @@ image/*; feh -g 640x480 '%s'; test=test -n "$DISPLAY"
 # Youtube videos are assigned a custom mime-type, which can be streamed with
 # vlc or youtube-dl.
 video/x-youtube; vlc '%s' --width 640 --height 480; test=test -n "$DISPLAY"
-video/x-youtube; youtube-dl -q -o - '%s' | mpv - --autofit 640x480; test=test -n "$DISPLAY"
+video/x-youtube; mpv --ytdl-format=best '%s' --autofit 640x480; test=test -n "$DISPLAY"
 
 # Mpv is a simple and effective video streamer
 video/webm; mpv '%s' --autofit 640x480 --loop=inf; test=test -n "$DISPLAY"


### PR DESCRIPTION
I simplified the mailcap entry for youtube videos using mpv. No need to pipe the stream from youtube-dl into mpv anymore since this latter can directly handle youtube urls. Bonus side effect : it's now possible to navigate backward and forward in the video.