### PR TITLE
Changed gif handler to mpv and removed redundant webm entry in mailcap

### DIFF
--- a/rtv/templates/mailcap
+++ b/rtv/templates/mailcap
@@ -26,6 +26,7 @@
 # Note that rtv returns a list of urls for imgur albums, so we don't put quotes
 # around the `%s`
 image/x-imgur-album; feh -g 640x480 %s; test=test -n "$DISPLAY"
+image/gif; mpv '%s' --autofit 640x480 --loop=inf; test=test -n "$DISPLAY"
 image/*; feh -g 640x480 '%s'; test=test -n "$DISPLAY"
 
 # Youtube videos are assigned a custom mime-type, which can be streamed with

--- a/rtv/templates/mailcap
+++ b/rtv/templates/mailcap
@@ -35,7 +35,6 @@ video/x-youtube; vlc '%s' --width 640 --height 480; test=test -n "$DISPLAY"
 video/x-youtube; mpv --ytdl-format=best '%s' --autofit 640x480; test=test -n "$DISPLAY"
 
 # Mpv is a simple and effective video streamer
-video/webm; mpv '%s' --autofit 640x480 --loop=inf; test=test -n "$DISPLAY"
 video/*; mpv '%s' --autofit 640x480 --loop=inf; test=test -n "$DISPLAY"
 
 ###############################################################################


### PR DESCRIPTION
Gifs were previously handled by feh which can only display the first frame. 