### PR TITLE
Drop python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: trusty
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ setuptools.setup(
         'Operating System :: POSIX',
         'Natural Language :: English',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
I'm going to follow suit from pytest and drop support for python 3.3.

https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst#deprecations-and-removals

For python 3.3 users (are there any out there?), rtv will still be installable through pip but the test suite will no longer be run.