### PR TITLE
Add --no-flash option to rtv

### DIFF
--- a/rtv/config.py
+++ b/rtv/config.py
@@ -80,6 +80,9 @@ def build_parser():
         help='Open external links using programs defined in the mailcap config')
     parser.add_argument(
         '-V', '--version', action='version', version='rtv '+__version__)
+    parser.add_argument(
+        '--no-flash', dest='flash', action='store_const', const=False,
+        help='Disable screen flashing')
     return parser
 
 
@@ -264,7 +267,8 @@ class Config(object):
             'oauth_redirect_port': partial(config.getint, 'rtv'),
             'oauth_scope': lambda x: rtv[x].split(','),
             'max_comment_cols': partial(config.getint, 'rtv'),
-            'hide_username': partial(config.getboolean, 'rtv')
+            'hide_username': partial(config.getboolean, 'rtv'),
+            'flash': partial(config.getboolean, 'rtv')
         }
 
         for key, func in params.items():

--- a/rtv/templates/rtv.cfg
+++ b/rtv/templates/rtv.cfg
@@ -16,6 +16,9 @@ ascii = False
 ; Turn on monochrome mode to disable color.
 monochrome = False
 
+; Flash when an invalid action is executed.
+flash = True
+
 ; Enable debugging by logging all HTTP requests and errors to the given file.
 ;log = /tmp/rtv.log
 

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -118,12 +118,14 @@ class Terminal(object):
             self._display = display
         return self._display
 
-    @staticmethod
-    def flash():
+    def flash(self):
         """
         Flash the screen to indicate that an action was invalid.
         """
-        return curses.flash()
+        if self.config['flash']:
+            return curses.flash()
+        else:
+            return None
 
     @staticmethod
     def curs_set(val):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,7 +91,8 @@ def test_config_get_args():
             '--copy-config',
             '--enable-media',
             '--theme', 'molokai',
-            '--list-themes']
+            '--list-themes',
+            '--no-flash']
 
     with mock.patch('sys.argv', ['rtv']):
         config_dict = Config.get_args()
@@ -115,6 +116,7 @@ def test_config_get_args():
         assert config['enable_media'] is True
         assert config['theme'] == 'molokai'
         assert config['list_themes'] is True
+        assert config['flash'] is False
 
 
 def test_config_link_deprecated():
@@ -148,7 +150,8 @@ def test_config_from_file():
         'enable_media': True,
         'max_comment_cols': 150,
         'hide_username': True,
-        'theme': 'molokai'}
+        'theme': 'molokai',
+        'flash': True}
 
     bindings = {
         'REFRESH': 'r, <KEY_F5>',

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -93,6 +93,13 @@ def test_terminal_functions(terminal):
     terminal.stdscr.addch.assert_called_with(3, 5, 'ch', 'attr')
 
 
+def test_terminal_no_flash(terminal):
+
+    terminal.config['flash'] = False
+    terminal.flash()
+    assert not curses.flash.called
+
+
 def test_terminal_clean_ascii(terminal):
 
     terminal.config['ascii'] = True


### PR DESCRIPTION
This pull request adds the option to disable screen flashing entirely. Also includes tests and everything else needed for a new rtv option.

Ref: #478