### PR TITLE
Add dark colorblind theme

### DIFF
--- a/rtv/themes/colorblind-dark.cfg
+++ b/rtv/themes/colorblind-dark.cfg
@@ -1,0 +1,63 @@
+# Black             ansi_235
+# White             ansi_253
+
+# Sky Blue          ansi_81
+# Bluish Green      ansi_36
+# Yellow            ansi_227
+# Blue              ansi_32
+# Vermillion        ansi_202
+# Reddish Purple    ansi_175
+
+
+[theme]
+;<element>            = <foreground>  <background>  <attributes>
+Normal                = ansi_253      ansi_235      normal
+Selected              = -             ansi_236      normal
+SelectedCursor        = -             -             reverse
+
+TitleBar              = ansi_81       -             bold+reverse
+OrderBar              = ansi_227      -             bold
+OrderBarHighlight     = ansi_227      -             bold+reverse
+HelpBar               = ansi_81       -             bold+reverse
+Prompt                = ansi_81       -             bold+reverse
+NoticeInfo            = -             -             bold
+NoticeLoading         = -             -             bold
+NoticeError           = -             -             bold
+NoticeSuccess         = -             -             bold
+
+CursorBlock           = -             -             -
+CursorBar1            = ansi_175      -             -
+CursorBar2            = ansi_81       -             -
+CursorBar3            = ansi_36       -             -
+CursorBar4            = ansi_227      -             -
+
+CommentAuthor         = ansi_32       -             bold
+CommentAuthorSelf     = ansi_36       -             bold
+CommentCount          = -             -             -
+CommentText           = -             -             -
+Created               = -             -             -
+Downvote              = ansi_202      -             bold
+Gold                  = ansi_227      -             bold
+HiddenCommentExpand   = -             -             bold
+HiddenCommentText     = -             -             -
+MultiredditName       = ansi_227      -             bold
+MultiredditText       = -             -             -
+NeutralVote           = -             -             bold
+NSFW                  = ansi_202      -             bold+reverse
+Saved                 = ansi_36       -             -
+Hidden                = ansi_227      -             -
+Score                 = -             -             -
+Separator             = -             -             bold
+Stickied              = ansi_36       -             -
+SubscriptionName      = ansi_227      -             bold
+SubscriptionText      = -             -             -
+SubmissionAuthor      = ansi_36       -             bold
+SubmissionFlair       = ansi_202           -             -
+SubmissionSubreddit   = ansi_227      -             -
+SubmissionText        = -             -             -
+SubmissionTitle       = -             -             bold
+SubmissionTitleSeen   = -             -             -
+Upvote                = ansi_36       -             bold
+Link                  = ansi_32       -             underline
+LinkSeen              = ansi_175      -             underline
+UserFlair             = ansi_227      -             bold


### PR DESCRIPTION
Added basic dark colorblind theme requested in #547. The colors were chosen using the guidelines seen in: 
[Tips + Tricks with Beamer for Economists](https://paulgp.github.io/beamer_tips.pdf) (PDF file page 10/40).