### PR TITLE
pager: Add RTV_PAGER to support a reddit-specific setting

### DIFF
--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -127,6 +127,7 @@ def main():
             ('$RTV_URLVIEWER', os.getenv('RTV_URLVIEWER')),
             ('$RTV_BROWSER', RTV_BROWSER),
             ('$BROWSER', BROWSER),
+            ('$RTV_PAGER', os.getenv('RTV_PAGER')),
             ('$PAGER', os.getenv('PAGER')),
             ('$VISUAL', os.getenv('VISUAL')),
             ('$EDITOR', os.getenv('EDITOR'))]

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -560,12 +560,17 @@ class Terminal(object):
 
     def open_pager(self, data, wrap=None):
         """
-        View a long block of text using the system's default pager.
+        View a long block of text using an external pager / viewer.  The setting
+        of the RTV_PAGER variable will be used if set, otherwise the system's
+        default pager is chosen, finally defaulting to 'less' if both RTV_PAGER
+        and PAGER is unset in the calling environment.
 
         The data string will be piped directly to the pager.
         """
 
-        pager = os.getenv('PAGER') or 'less'
+        pager = os.getenv('RTV_PAGER')
+        if pager is None:
+                pager = os.getenv('PAGER') or 'less'
         command = shlex.split(pager)
 
         if wrap:


### PR DESCRIPTION
Reddit submissions and comments are styled with Markdown.  If you have a
Markdown-aware pager/viewer on your system it is convenient to be able to
use it rather than the default 'less'/'more'/etc. one used for everything
else on the system.  Support a high-priority environment variable that
will be consulted prior to checking $PAGER and/or defaulting to 'less'.

Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>