### PR TITLE
Issue #597: Autologin configuration

### DIFF
--- a/rtv/__main__.py
+++ b/rtv/__main__.py
@@ -205,7 +205,7 @@ def main():
 
             # Authorize on launch if the refresh token is present
             oauth = OAuthHelper(reddit, term, config)
-            if config.refresh_token:
+            if config['autologin'] and config.refresh_token:
                 oauth.authorize()
 
             page = None

--- a/rtv/config.py
+++ b/rtv/config.py
@@ -65,6 +65,9 @@ def build_parser():
         '--non-persistent', dest='persistent', action='store_const', const=False,
         help='Forget the authenticated user when the program exits')
     parser.add_argument(
+        '--no-autologin', dest='autologin', action='store_const', const=False,
+        help='Do not authenticate automatically on startup')
+    parser.add_argument(
         '--clear-auth', dest='clear_auth', action='store_const', const=True,
         help='Remove any saved user data before launching')
     parser.add_argument(
@@ -259,6 +262,7 @@ class Config(object):
             'ascii': partial(config.getboolean, 'rtv'),
             'monochrome': partial(config.getboolean, 'rtv'),
             'persistent': partial(config.getboolean, 'rtv'),
+            'autologin': partial(config.getboolean, 'rtv'),
             'clear_auth': partial(config.getboolean, 'rtv'),
             'enable_media': partial(config.getboolean, 'rtv'),
             'history_size': partial(config.getint, 'rtv'),

--- a/rtv/config.py
+++ b/rtv/config.py
@@ -258,8 +258,8 @@ class Config(object):
         params = {
             'ascii': partial(config.getboolean, 'rtv'),
             'monochrome': partial(config.getboolean, 'rtv'),
-            'clear_auth': partial(config.getboolean, 'rtv'),
             'persistent': partial(config.getboolean, 'rtv'),
+            'clear_auth': partial(config.getboolean, 'rtv'),
             'enable_media': partial(config.getboolean, 'rtv'),
             'history_size': partial(config.getint, 'rtv'),
             'oauth_redirect_port': partial(config.getint, 'rtv'),

--- a/rtv/templates/rtv.cfg
+++ b/rtv/templates/rtv.cfg
@@ -31,6 +31,9 @@ subreddit = front
 ; Allow rtv to store reddit authentication credentials between sessions.
 persistent = True
 
+; Automatically log in on startup, if credentials are available.
+autologin = True
+
 ; Clear any stored credentials when the program starts.
 clear_auth = False
 


### PR DESCRIPTION
This PR introduces the `--no-autologin` cli parameter and the correlating `autologin` config option. A user could be willing to skip automatic login, to speed up the startup of rtv.