### PR TITLE
Fix crash in extract_links when self text is blank

### DIFF
--- a/rtv/content.py
+++ b/rtv/content.py
@@ -219,7 +219,7 @@ class Content(object):
         data['type'] = 'Submission'
         data['title'] = sub.title
         data['text'] = sub.selftext
-        data['html'] = sub.selftext_html
+        data['html'] = sub.selftext_html or ''
         data['created'] = cls.humanize_timestamp(sub.created_utc)
         data['created_long'] = cls.humanize_timestamp(sub.created_utc, True)
         data['comments'] = '{0} comments'.format(sub.num_comments)
@@ -321,7 +321,7 @@ class Content(object):
     @staticmethod
     def extract_links(html):
         """
-        Extract a list of hyperlinks from an HTMl document.
+        Extract a list of hyperlinks from an HTML document.
         """
         links = []
         soup = BeautifulSoup(html, 'html.parser')


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/user/builds/rtv/rtv/__main__.py", line 252, in <module>
    sys.exit(main())
  File "/home/user/builds/rtv/rtv/__main__.py", line 231, in main
    page.open_submission(url=url)
  File "/home/user/builds/rtv/rtv/subreddit_page.py", line 186, in open_submission
    page.loop()
  File "/home/user/builds/rtv/rtv/page.py", line 84, in loop
    self.controller.trigger(ch)
  File "/home/user/builds/rtv/rtv/objects.py", line 604, in trigger
    return func(self.instance, *args, **kwargs)
  File "/home/user/builds/rtv/rtv/submission_page.py", line 148, in open_link
    opened_link = self.prompt_and_open_link(data)
  File "/home/user/builds/rtv/rtv/submission_page.py", line 162, in prompt_and_open_link
    extracted_links = self.content.extract_links(data['html'])
  File "/home/user/builds/rtv/rtv/content.py", line 327, in extract_links
    soup = BeautifulSoup(html, 'html.parser')
  File "/usr/lib/python3.7/site-packages/bs4/__init__.py", line 246, in __init__
    elif len(markup) <= 256 and (
TypeError: object of type 'NoneType' has no len()
```