### PR TITLE
Add max column width for pager

### DIFF
--- a/rtv/config.py
+++ b/rtv/config.py
@@ -269,6 +269,7 @@ class Config(object):
             'oauth_redirect_port': partial(config.getint, 'rtv'),
             'oauth_scope': lambda x: rtv[x].split(','),
             'max_comment_cols': partial(config.getint, 'rtv'),
+            'max_pager_cols': partial(config.getint, 'rtv'),
             'hide_username': partial(config.getboolean, 'rtv'),
             'flash': partial(config.getboolean, 'rtv')
         }

--- a/rtv/submission_page.py
+++ b/rtv/submission_page.py
@@ -181,6 +181,9 @@ class SubmissionPage(Page):
 
         n_rows, n_cols = self.term.stdscr.getmaxyx()
 
+        if self.config['max_pager_cols'] is not None:
+            n_cols = min(n_cols, self.config['max_pager_cols'])
+
         data = self.get_selected_item()
         if data['type'] == 'Submission':
             text = '\n\n'.join((data['permalink'], data['text']))

--- a/rtv/templates/rtv.cfg
+++ b/rtv/templates/rtv.cfg
@@ -46,6 +46,9 @@ enable_media = False
 ; Maximum number of columns for a comment
 max_comment_cols = 120
 
+; Maximum number of columns for pager
+;max_pager_cols = 70
+
 ; Hide username if logged in, display "Logged in" instead
 hide_username = False
 


### PR DESCRIPTION
Some times I find it easier to read the text when it's wrapped to 70 columns. So I've added an option to set the maximum width (disabled by default) for the pager.