### PR TITLE
Mailcap: support URLs and files

### DIFF
--- a/rtv/templates/mailcap
+++ b/rtv/templates/mailcap
@@ -44,7 +44,7 @@ video/*; mpv '%s' --autofit 640x480 --loop=inf; test=test -n "$DISPLAY"
 
 # View images directly in your terminal with iTerm2
 # curl -L https://iterm2.com/misc/install_shell_integration_and_utilities.sh | bash
-# image/*; curl -s %s | ~/.iterm2/imgcat && read -n 1; needsterminal
+# image/*; bash -c '[[ "%s" == http*  ]] && (curl -s %s | ~/.iterm2/imgcat) || ~/.iterm2/imgcat %s' && read -n 1; needsterminal
 
 # View true images in the terminal, supported by rxvt-unicode, xterm and st
 # Requires the w3m-img package


### PR DESCRIPTION
The default mailcap for rtv is nice with some presets for viewing images in iTerm2, but it expects that paths are URLs. Other apps that use mailcap, such as mutt/neomutt, provide paths on the filesystem instead of URLs.

This PR modifies the mailcap template to check if the provided path starts with http, and uses curl to fetch the image only if the path starts with http. Otherwise, it directly pushes it to iterm2's imgcat. This makes it possible for mutt and rtv to share the same mailcap.