### PR TITLE
Update Arch Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ See [Repology](https://repology.org/metapackage/rtv/packages) for an up-to-date 
 # macOS
 $ brew install rtv
 
-# Arch (use whichever AUR helper you prefer)
-$ pacaur -S rtv
+# Arch
+$ pacman -S rtv
 
 # Nix
 $ nix-env -i rtv


### PR DESCRIPTION
The Arch package has been moved to the [official community repository](https://www.archlinux.org/packages/community/any/rtv/).