### PR TITLE
Improve comment formatting for markdown code block

### DIFF
--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -911,7 +911,8 @@ class Terminal(object):
         # Pattern can span multiple lines, allows dot to match newline chars
         flags = re.MULTILINE | re.DOTALL
         pattern = '<!--{token}(.*?){token}-->'.format(token=TOKEN)
-        return re.sub(pattern, '', text, flags=flags).strip()
+        text = re.sub(pattern, '', text, flags=flags)
+        return re.sub( '^[\s\n]*\n', '', text, flags=flags).rstrip()
 
     def clear_screen(self):
         """


### PR DESCRIPTION
Lines beginning with four space are treated as code on reddit.
`rtv` strips leading whitespace before sending posts to reddit thus preventing code blocks from being recoginzed.
This fix should strip only leading empty lines rather than all leading whitespace.