### PR TITLE
Fix edge-case when printing terminal title

### DIFF
--- a/rtv/page.py
+++ b/rtv/page.py
@@ -418,8 +418,11 @@ class Page(object):
         # Set the terminal title
         if len(sub_name) > 50:
             title = sub_name.strip('/')
-            title = title.rsplit('/', 1)[1]
             title = title.replace('_', ' ')
+            try:
+                title = title.rsplit('/', 1)[1]
+            except IndexError:
+                pass
         else:
             title = sub_name
 


### PR DESCRIPTION
Handles #640 

I wasn't able to reproduce the reported error, but this should prevent the app from crashing.