### PR TITLE
Prevent stripping newlines in the middle of markdown submissions

### DIFF
--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -912,7 +912,7 @@ class Terminal(object):
         flags = re.MULTILINE | re.DOTALL
         pattern = '<!--{token}(.*?){token}-->'.format(token=TOKEN)
         text = re.sub(pattern, '', text, flags=flags)
-        return re.sub( '^[\s\n]*\n', '', text, flags=flags).rstrip()
+        return re.sub('\A[\s\n]*\n', '', text, flags=flags).rstrip()
 
     def clear_screen(self):
         """

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -709,6 +709,10 @@ def test_terminal_strip_instructions(terminal):
     text = '\n    \n    code\n    block\n'
     assert terminal.strip_instructions(text) == '    code\n    block'
 
+    # However, blank lines in the middle of comment should not be stripped
+    text = 'paragraph 1\n\nparagraph 2\n'
+    assert terminal.strip_instructions(text) == 'paragraph 1\n\nparagraph 2'
+
 
 def test_terminal_get_link_pages(terminal):
 


### PR DESCRIPTION
Fixes regression described in #649 