### PR TITLE
Footer displays 'login' or 'logout' when suitable.

### DIFF
--- a/rtv/docs.py
+++ b/rtv/docs.py
@@ -60,7 +60,7 @@ https://github.com/michael-lazar/rtv
   i     : Display new messages
   s     : Show subscribed subreddits
   S     : Show subscribed multireddits
-  w     : Save a submission/comment 
+  w     : Save a submission/comment
   l     : View comments, or open comment in pager
   h     : Return to subreddit
   o     : Open the submission or comment url
@@ -106,6 +106,10 @@ BANNER_SEARCH = """
 
 FOOTER_SUBREDDIT = """
 [?]Help [q]Quit [l]Comments [/]Prompt [u]Login [o]Open [c]Post [a/z]Vote [r]Refresh
+"""
+
+FOOTER_SUBREDDIT_LOGGED_IN = """
+[?]Help [q]Quit [l]Comments [/]Prompt [u]Logout [o]Open [c]Post [a/z]Vote [r]Refresh
 """
 
 FOOTER_SUBMISSION = """

--- a/rtv/page.py
+++ b/rtv/page.py
@@ -227,6 +227,8 @@ class Page(object):
         else:
             self.oauth.authorize()
 
+        self.refresh_content()
+
     @PageController.register(Command('DELETE'))
     @logged_in
     def delete_item(self):

--- a/rtv/subreddit_page.py
+++ b/rtv/subreddit_page.py
@@ -33,12 +33,14 @@ class SubredditPage(Page):
         self.content = SubredditContent.from_name(reddit, name, term.loader)
         self.nav = Navigator(self.content.get)
         self.toggled_subreddit = None
+        self.FOOTER = self.reload_footer()
 
     def refresh_content(self, order=None, name=None):
         """
         Re-download all submissions and reset the page index
         """
 
+        self.FOOTER = self.reload_footer()
         order = order or self.content.order
 
         # Preserve the query if staying on the current page
@@ -59,6 +61,12 @@ class SubredditPage(Page):
                 self.reddit, name, self.term.loader, order=order, query=query)
         if not self.term.loader.exception:
             self.nav = Navigator(self.content.get)
+
+    def reload_footer(self):
+      if self.reddit.user is None:
+        return docs.FOOTER_SUBREDDIT
+      else:
+        return docs.FOOTER_SUBREDDIT_LOGGED_IN
 
     @SubredditController.register(Command('SORT_HOT'))
     def sort_content_hot(self):


### PR DESCRIPTION
Fixes issue #647 

The correct term (login/logout) is now displayed in the footer, respective of if a user is currently logged in or not.

Note: I'm not a big fan of self.FOOTER being capitalised like a constant because.. well, it's not. But changing this broke functionality in the parent class so I decided to keep the diff small. If desired though I can go through and fix this up, the fix will just get a fair bit more complicated.