### PR TITLE
Add option to force opening links in new browser window

### DIFF
--- a/rtv/config.py
+++ b/rtv/config.py
@@ -261,6 +261,7 @@ class Config(object):
         if config.has_section('rtv'):
             rtv = dict(config.items('rtv'))
 
+        # convert non-string params to their typed representation
         params = {
             'ascii': partial(config.getboolean, 'rtv'),
             'monochrome': partial(config.getboolean, 'rtv'),
@@ -274,7 +275,8 @@ class Config(object):
             'max_comment_cols': partial(config.getint, 'rtv'),
             'max_pager_cols': partial(config.getint, 'rtv'),
             'hide_username': partial(config.getboolean, 'rtv'),
-            'flash': partial(config.getboolean, 'rtv')
+            'flash': partial(config.getboolean, 'rtv'),
+            'force_new_browser_window': partial(config.getboolean, 'rtv')
         }
 
         for key, func in params.items():

--- a/rtv/templates/rtv.cfg
+++ b/rtv/templates/rtv.cfg
@@ -57,6 +57,9 @@ hide_username = False
 ; been installed into either the custom of default theme paths.
 ;theme = molokai
 
+; Open a new browser window instead of a new tab in existing instance
+force_new_browser_window = False
+
 ################
 # OAuth Settings
 ################
@@ -81,9 +84,6 @@ oauth_scope = edit,history,identity,mysubreddits,privatemessages,read,report,sav
 ; from imgur links and albums so they can be opened with mailcap.
 ; See https://imgur.com/account/settings/apps to generate your own key.
 imgur_client_id = 93396265f59dec9
-
-; Open a new browser window instead of a new tab in existing instance
-force_new_browser_window = False
 
 [bindings]
 ##############

--- a/rtv/templates/rtv.cfg
+++ b/rtv/templates/rtv.cfg
@@ -82,6 +82,9 @@ oauth_scope = edit,history,identity,mysubreddits,privatemessages,read,report,sav
 ; See https://imgur.com/account/settings/apps to generate your own key.
 imgur_client_id = 93396265f59dec9
 
+; Open a new browser window instead of a new tab in existing instance
+force_new_browser_window = False
+
 [bindings]
 ##############
 # Key Bindings

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -599,7 +599,10 @@ class Terminal(object):
                     try:
                         os.dup2(null, 1)
                         os.dup2(null, 2)
-                        webbrowser.open_new_tab(url)
+                        if self.config['force_new_browser_window']:
+                            webbrowser.open_new(url)
+                        else:
+                            webbrowser.open_new_tab(url)
                     finally:
                         try:
                             os.close(null)

--- a/rtv/terminal.py
+++ b/rtv/terminal.py
@@ -632,7 +632,10 @@ class Terminal(object):
                         pass
         else:
             with self.suspend():
-                webbrowser.open_new_tab(url)
+                if self.config['force_new_browser_window']:
+                    webbrowser.open_new(url)
+                else:
+                    webbrowser.open_new_tab(url)
 
     def open_pager(self, data, wrap=None):
         """


### PR DESCRIPTION
#669 

Added an option to the config file, _force_new_browser_window_, which when set opens links 
in a a new window instead of a new tab in the running browser. 

[Note] Option works with old config files. If the config file doesn't have this option defined the old behavior (open in new tab) will be performed.