### PR TITLE
Make sure feh scales the image to fit the window

### DIFF
--- a/rtv/templates/mailcap
+++ b/rtv/templates/mailcap
@@ -25,9 +25,9 @@
 # Feh is a simple and effective image viewer
 # Note that rtv returns a list of urls for imgur albums, so we don't put quotes
 # around the `%s`
-image/x-imgur-album; feh -g 640x480 %s; test=test -n "$DISPLAY"
+image/x-imgur-album; feh -g 640x480  -. %s; test=test -n "$DISPLAY"
 image/gif; mpv '%s' --autofit 640x480 --loop=inf; test=test -n "$DISPLAY"
-image/*; feh -g 640x480 '%s'; test=test -n "$DISPLAY"
+image/*; feh -g 640x480 -. '%s'; test=test -n "$DISPLAY"
 
 # Youtube videos are assigned a custom mime-type, which can be streamed with
 # vlc or youtube-dl.


### PR DESCRIPTION
This is a real small PR for the mailcap template, but it's something I was missing when viewing images.
```bash
-., --scale-down                                                                                                                                                                                            
  Scale images to fit window geometry (defaults to screen size when no geometry was specified).
  Note that the window geometry is not updated when changing images at the moment.
  This option is recommended for tiling window managers.  This option is ignored when in 
  fullscreen and thumbnail list mode. 
  In tiling environments, this also causes the image to be centered in the window.
```